### PR TITLE
override configuration correctly, even if passed PluginConfig has args data on PluginConfig.Args.Raw

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,3 +58,4 @@ issues:
         - funlen
         - goerr113
         - errcheck
+        - cyclop

--- a/scheduler/plugin/plugins.go
+++ b/scheduler/plugin/plugins.go
@@ -72,8 +72,10 @@ func NewRegistry(informerFactory informers.SharedInformerFactory, client clients
 // NewPluginConfig converts []v1beta2.PluginConfig for simulator.
 // Passed []v1beta.PluginConfig overrides default config values.
 //
-// NewPluginConfig expects that passed v1beta2.PluginConfig has data of Args in only one of PluginConfig.Args.Raw or PluginConfig.Args.Object.
-// But, if Args data exists in both PluginConfig.Args.Raw and PluginConfig.Args.Object, PluginConfig.Args.Object takes precedence.
+// NewPluginConfig expects that either PluginConfig.Args.Raw or PluginConfig.Args.Object has data
+// in the passed v1beta2.PluginConfig parameter.
+// If data exists in both PluginConfig.Args.Raw and PluginConfig.Args.Object, PluginConfig.Args.Raw would be ignored
+// since PluginConfig.Args.Object has higher priority.
 //nolint:funlen,cyclop
 func NewPluginConfig(pc []v1beta2.PluginConfig) ([]v1beta2.PluginConfig, error) {
 	defaultcfg, err := defaultconfig.DefaultSchedulerConfig()
@@ -91,7 +93,7 @@ func NewPluginConfig(pc []v1beta2.PluginConfig) ([]v1beta2.PluginConfig, error) 
 		name := pc[i].Name
 		ret := pluginConfig[name].DeepCopy()
 
-		// v1beta2.PluginConfig may have data on pc[i].Args.Raw as []byte.
+		// v1beta2.PluginConfig may have data in pc[i].Args.Raw as []byte.
 		// We have to encoding it in this case.
 		if len(pc[i].Args.Raw) != 0 {
 			// override default configuration
@@ -101,7 +103,8 @@ func NewPluginConfig(pc []v1beta2.PluginConfig) ([]v1beta2.PluginConfig, error) 
 		}
 
 		if pc[i].Args.Object != nil {
-			// If Args data exists in both PluginConfig.Args.Raw and PluginConfig.Args.Object, PluginConfig.Args.Object takes precedence.
+			// If data exists in both PluginConfig.Args.Raw and PluginConfig.Args.Object,
+			// PluginConfig.Args.Raw would be ignored
 			ret.Object = pc[i].Args.Object
 		}
 

--- a/scheduler/plugin/plugins.go
+++ b/scheduler/plugin/plugins.go
@@ -74,6 +74,7 @@ func NewRegistry(informerFactory informers.SharedInformerFactory, client clients
 //
 // NewPluginConfig expects that passed v1beta2.PluginConfig has data of Args in only one of PluginConfig.Args.Raw or PluginConfig.Args.Object.
 // But, if Args data exists in both PluginConfig.Args.Raw and PluginConfig.Args.Object, PluginConfig.Args.Object takes precedence.
+//nolint:funlen,cyclop
 func NewPluginConfig(pc []v1beta2.PluginConfig) ([]v1beta2.PluginConfig, error) {
 	defaultcfg, err := defaultconfig.DefaultSchedulerConfig()
 	if err != nil || len(defaultcfg.Profiles) != 1 {

--- a/scheduler/plugin/plugins_test.go
+++ b/scheduler/plugin/plugins_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sort"
 	"testing"
@@ -205,7 +206,7 @@ func Test_NewPluginConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "success with plugin config of filter/score",
+			name: "success with plugin config on Args.Object",
 			pc: []v1beta2.PluginConfig{
 				{
 					Name: "InterPodAffinity",
@@ -217,6 +218,63 @@ func Test_NewPluginConfig(t *testing.T) {
 							},
 							HardPodAffinityWeight: &hardPodAffinityWeight,
 						},
+					},
+				},
+			},
+			want: func() []v1beta2.PluginConfig {
+				pc := defaultPluginConfig()
+				for i := range pc {
+					if pc[i].Name == "InterPodAffinity" {
+						pc[i] = v1beta2.PluginConfig{
+							Name: "InterPodAffinity",
+							Args: runtime.RawExtension{
+								Object: &v1beta2.InterPodAffinityArgs{
+									TypeMeta: metav1.TypeMeta{
+										Kind:       "InterPodAffinityArgs",
+										APIVersion: "kubescheduler.config.k8s.io/v1beta2",
+									},
+									HardPodAffinityWeight: &hardPodAffinityWeight,
+								},
+							},
+						}
+					}
+					if pc[i].Name == "InterPodAffinityForSimulator" {
+						pc[i] = v1beta2.PluginConfig{
+							Name: "InterPodAffinityForSimulator",
+							Args: runtime.RawExtension{
+								Object: &v1beta2.InterPodAffinityArgs{
+									TypeMeta: metav1.TypeMeta{
+										Kind:       "InterPodAffinityArgs",
+										APIVersion: "kubescheduler.config.k8s.io/v1beta2",
+									},
+									HardPodAffinityWeight: &hardPodAffinityWeight,
+								},
+							},
+						}
+					}
+				}
+
+				return pc
+			}(),
+			wantErr: false,
+		},
+		{
+			name: "success with plugin config on Args.Raw ",
+			pc: []v1beta2.PluginConfig{
+				{
+					Name: "InterPodAffinity",
+					Args: runtime.RawExtension{
+						Raw: func() []byte {
+							cfg := v1beta2.InterPodAffinityArgs{
+								TypeMeta: metav1.TypeMeta{
+									Kind:       "InterPodAffinityArgs",
+									APIVersion: "kubescheduler.config.k8s.io/v1beta2",
+								},
+								HardPodAffinityWeight: &hardPodAffinityWeight,
+							}
+							d, _ := json.Marshal(cfg)
+							return d
+						}(),
 					},
 				},
 			},

--- a/scheduler/plugin/plugins_test.go
+++ b/scheduler/plugin/plugins_test.go
@@ -259,6 +259,72 @@ func Test_NewPluginConfig(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Success: if data exists in both PluginConfig.Args.Raw and PluginConfig.Args.Object," +
+				"PluginConfig.Args.Raw would be ignored",
+			pc: []v1beta2.PluginConfig{
+				{
+					Name: "InterPodAffinity",
+					Args: runtime.RawExtension{
+						Object: &v1beta2.InterPodAffinityArgs{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "InterPodAffinityArgs",
+								APIVersion: "kubescheduler.config.k8s.io/v1beta2",
+							},
+							HardPodAffinityWeight: &hardPodAffinityWeight,
+						},
+						Raw: func() []byte {
+							anotherHardPodAffinityWeight := hardPodAffinityWeight + 1
+							cfg := v1beta2.InterPodAffinityArgs{
+								TypeMeta: metav1.TypeMeta{
+									Kind:       "InterPodAffinityArgs",
+									APIVersion: "kubescheduler.config.k8s.io/v1beta2",
+								},
+								HardPodAffinityWeight: &anotherHardPodAffinityWeight,
+							}
+							d, _ := json.Marshal(cfg)
+							return d
+						}(),
+					},
+				},
+			},
+			want: func() []v1beta2.PluginConfig {
+				pc := defaultPluginConfig()
+				for i := range pc {
+					if pc[i].Name == "InterPodAffinity" {
+						pc[i] = v1beta2.PluginConfig{
+							Name: "InterPodAffinity",
+							Args: runtime.RawExtension{
+								Object: &v1beta2.InterPodAffinityArgs{
+									TypeMeta: metav1.TypeMeta{
+										Kind:       "InterPodAffinityArgs",
+										APIVersion: "kubescheduler.config.k8s.io/v1beta2",
+									},
+									HardPodAffinityWeight: &hardPodAffinityWeight,
+								},
+							},
+						}
+					}
+					if pc[i].Name == "InterPodAffinityForSimulator" {
+						pc[i] = v1beta2.PluginConfig{
+							Name: "InterPodAffinityForSimulator",
+							Args: runtime.RawExtension{
+								Object: &v1beta2.InterPodAffinityArgs{
+									TypeMeta: metav1.TypeMeta{
+										Kind:       "InterPodAffinityArgs",
+										APIVersion: "kubescheduler.config.k8s.io/v1beta2",
+									},
+									HardPodAffinityWeight: &hardPodAffinityWeight,
+								},
+							},
+						}
+					}
+				}
+
+				return pc
+			}(),
+			wantErr: false,
+		},
+		{
 			name: "success with plugin config on Args.Raw ",
 			pc: []v1beta2.PluginConfig{
 				{

--- a/scheduler/plugin/plugins_test.go
+++ b/scheduler/plugin/plugins_test.go
@@ -143,6 +143,7 @@ func TestConvertForSimulator(t *testing.T) {
 	}
 }
 
+//nolint:gocognit // it is because of huge test cases.
 func Test_NewPluginConfig(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Hi team~

Fixes: #12 

This PR fixes the bug on restarting scheduler. 
The function NewPluginConfig failed to override configuration correctly when passed PluginConfig has args data on PluginConfig.Args.Raw not on PluginConfig.Args.Object. So, fixed it

/kind bug