### PR TITLE
Workaround: v-data-table cannot scroll when the bar cannot be scrolled vertically

### DIFF
--- a/web/components/ResourceBar/ResourceBar.vue
+++ b/web/components/ResourceBar/ResourceBar.vue
@@ -32,6 +32,8 @@
     <template v-if="!editmode">
       <SchedulingResults />
       <ResourceDefinitionTree :items="treeData" />
+      <!-- This is need to avoid bug on vuetify -->
+      <div style="height: 80%;"></div>
     </template>
   </v-navigation-drawer>
 </template>

--- a/web/components/ResourceBar/ResourceBar.vue
+++ b/web/components/ResourceBar/ResourceBar.vue
@@ -32,7 +32,7 @@
     <template v-if="!editmode">
       <SchedulingResults />
       <ResourceDefinitionTree :items="treeData" />
-      <!-- This is need to avoid bug on vuetify -->
+      <!-- This is required to work around the vuetify's bug, refer more details in #10 -->
       <div style="height: 80%;"></div>
     </template>
   </v-navigation-drawer>


### PR DESCRIPTION
Fixes #10 
It seems that v-data-table(vuetify component used to show table) cannot scroll horizontally when the v-navigation-drawer cannot be scrolled vertically 🤔  and it causes bug #10.

I add `<div>` with height as hot fix so that v-navigation-drawer always can be scrolled vertically.

/kind bug