### PR TITLE
Set environment variable HOST=0.0.0.0 to  simulator-frontend in docker-compse.yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     image: simulator-frontend
     restart: always
     container_name: simulator-frontend
+    environment:
+      - HOST=0.0.0.0
     ports:
     - "3000:3000"
     tty: true


### PR DESCRIPTION
## Issue
fix #23 

## What
- Set environment variable `HOST=0.0.0.0` to  simulator-frontend in docker-compse.yaml