### PR TITLE
use https instead of ssh for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "submodules/kubernetes"]
 	path = submodules/kubernetes
-	url = git@github.com:kubernetes/kubernetes.git
+	url = https://github.com/kubernetes/kubernetes.git


### PR DESCRIPTION
Jobs post-kube-scheduler-simulator-push were failed.
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kube-scheduler-simulator-push-images/1456617270737375232

error log:

```
$ git submodule update --init --recursive
Submodule 'submodules/kubernetes' (git@github.com:kubernetes/kubernetes.git) registered for path 'submodules/kubernetes'
Cloning into '/home/prow/go/src/github.com/kubernetes-sigs/kube-scheduler-simulator/submodules/kubernetes'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:kubernetes/kubernetes.git' into submodule path '/home/prow/go/src/github.com/kubernetes-sigs/kube-scheduler-simulator/submodules/kubernetes' failed
Failed to clone 'submodules/kubernetes'. Retry scheduled
Cloning into '/home/prow/go/src/github.com/kubernetes-sigs/kube-scheduler-simulator/submodules/kubernetes'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:kubernetes/kubernetes.git' into submodule path '/home/prow/go/src/github.com/kubernetes-sigs/kube-scheduler-simulator/submodules/kubernetes' failed
Failed to clone 'submodules/kubernetes' a second time, aborting
# Error: exit status 1
```

I also asked it on test-infra: https://github.com/kubernetes/test-infra/issues/24268