### PR TITLE
use --openssl-legacy-provider option 

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -12,6 +12,7 @@ FROM node:alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
+ENV NODE_OPTIONS --openssl-legacy-provider
 RUN yarn build && yarn install --production --ignore-scripts --prefer-offline
 
 FROM node:alpine AS runner


### PR DESCRIPTION
Fixes #38 

Now, we cannot build frontend docker image with this error.
```
ERROR  Error: error:0308010C:digital envelope routines::unsupported
```

This issue is due to webpack/webpack#14532 and we can solve this issue with `ENV NODE_OPTIONS --openssl-legacy-provider`.