### PR TITLE
pin node image to Node.js v16

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:alpine AS deps
+FROM node:16-alpine AS deps
 
 RUN apk update && \
     apk upgrade && \
@@ -8,13 +8,13 @@ WORKDIR /app
 COPY package.json yarn.lock ./
 RUN yarn install --frozen-lockfile
 
-FROM node:alpine AS builder
+FROM node:16-alpine AS builder
 WORKDIR /app
 COPY . .
 COPY --from=deps /app/node_modules ./node_modules
 RUN yarn build && yarn install --production --ignore-scripts --prefer-offline
 
-FROM node:alpine AS runner
+FROM node:16-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production


### PR DESCRIPTION
current latest node image is Node.js version v17. Using latest image should break codes unexpectedly.
Also, odd-numbered releases of Node.js is [short term version](https://nodejs.org/en/about/releases/).

Related: https://github.com/kubernetes-sigs/kube-scheduler-simulator/issues/38