### PR TITLE
Fix syntax error on cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -27,6 +27,6 @@ options:
 # this will push these images, or cause the build to fail if they weren't built.
 images:
   - 'gcr.io/$PROJECT_ID/simulator-frontend:$_GIT_TAG'
-  - 'gcr.io/$PROJECT_ID/simulator-backend:latest
+  - 'gcr.io/$PROJECT_ID/simulator-backend:latest'
   - 'gcr.io/$PROJECT_ID/simulator-frontend:$_GIT_TAG'
-  - 'gcr.io/$PROJECT_ID/simulator-backend:latest
+  - 'gcr.io/$PROJECT_ID/simulator-backend:latest'


### PR DESCRIPTION
Hello. 
Sorry, I forgot to add `'` at some ends on `cloudbuild.yaml` in #21  🤦‍♂️

```
ERROR: (gcloud.builds.submit) parsing /home/prow/go/src/github.com/kubernetes-sigs/kube-scheduler-simulator/cloudbuild.yaml: while parsing a block collection
  in "/home/prow/go/src/github.com/kubernetes-sigs/kube-scheduler-simulator/cloudbuild.yaml", line 29, column 3
expected <block end>, but found '<scalar>'
  in "/home/prow/go/src/github.com/kubernetes-sigs/kube-scheduler-simulator/cloudbuild.yaml", line 31, column 6
```
https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-kube-scheduler-simulator-push-images/1468300940288200704