### PR TITLE
Fix reset scheduler configuration endpoint path

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -44,7 +44,7 @@ restart scheduler with default configuration.
 
 ### HTTP Request
 
-`PUT /api/v1/schedulerconfiguration`
+`PUT /api/v1/schedulerconfiguration/reset`
 
 ### Request Body
 

--- a/server/server.go
+++ b/server/server.go
@@ -46,7 +46,7 @@ func NewSimulatorServer(cfg *config.Config, dic *di.Container) *SimulatorServer 
 
 	v1.GET("/schedulerconfiguration", schedulercfgHandler.GetSchedulerConfig)
 	v1.POST("/schedulerconfiguration", schedulercfgHandler.ApplySchedulerConfig)
-	v1.PUT("/schedulerconfiguration", schedulercfgHandler.ResetScheduler)
+	v1.PUT("/schedulerconfiguration/reset", schedulercfgHandler.ResetScheduler)
 
 	v1.GET("/nodes", nodeHandler.ListNode)
 	v1.POST("/nodes", nodeHandler.ApplyNode)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

We cannot guess what `PUT /api/v1/schedulerconfiguration` will do. 
(I should've pointed it when I reviewed #54 😓)

This PR change the endpoint to `PUT /api/v1/schedulerconfiguration/reset`

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Ref #26 

#### Special notes for your reviewer:

This PR is not needed in case that we re-design #26 to create one API to reset all resources and scheduler config.
So, let me `/hold` this. 

/cc @sivchari 
/hold
/label tide/merge-method-squash
