### PR TITLE
enable admission control with `Priority` admission plugin to support Preemption

### DIFF
--- a/web/components/lib/templates/pod.yaml
+++ b/web/components/lib/templates/pod.yaml
@@ -17,7 +17,7 @@ spec:
       terminationMessagePolicy: File
       imagePullPolicy: IfNotPresent
   restartPolicy: Always
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 0
   dnsPolicy: ClusterFirst
   securityContext: {}
   enableServiceLinks: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

- enable admission control with `Priority` admission plugin to support Preemption
- change terminationGracePeriodSeconds on template to 0. `terminationGracePeriodSeconds` must be 0 to be preempted on simulator. This is because we don't run kubelet on simulator and if `terminationGracePeriodSeconds` != 0, the Pod isn't deleted forever. (I will add this behavior to the doc later.)

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #74

#### Special notes for your reviewer:


/label tide/merge-method-squash
