### PR TITLE
fix(frontend): react on nuxt telemetry user input during `yarn start`

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -18,6 +18,7 @@ FROM node:16-alpine AS runner
 WORKDIR /app
 
 ENV NODE_ENV production
+ENV NUXT_TELEMETRY_DISABLED 1
 
 RUN addgroup -g 1001 -S nodejs
 RUN adduser -S nuxtjs -u 1001


### PR DESCRIPTION
Signed-off-by: skuethe <56306041+skuethe@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR adds the required `nuxt` telementry user input via env variable during the container image build. Without this input

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #87 

#### Special notes for your reviewer:

There are two possibilities to avoid the telemetry user input during startup:
https://github.com/nuxt/telemetry#opting-out

1. modify a setting in a `nuxt.config`
2. set an environment var

I tried to modify the file `web/nuxt.config.js` and then re-enable to copy command in the `web/Dockerfile`, but that does seem to create a lot of other issues.
So this PR is setting the env var in the `web/Dockerfile`.

/label tide/merge-method-squash
