### PR TITLE
add configuration to change the URL of kube-apiserver

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@ var ErrEmptyEnv = errors.New("env is needed, but empty")
 // Config is configuration for simulator.
 type Config struct {
 	Port                int
+	ApiUrl              string
 	EtcdURL             string
 	FrontendURL         string
 	InitialSchedulerCfg *v1beta2config.KubeSchedulerConfiguration
@@ -40,6 +41,8 @@ func NewConfig() (*Config, error) {
 		return nil, xerrors.Errorf("get frontend URL: %w", err)
 	}
 
+	apiurl := getAPIURL()
+
 	initialschedulerCfg, err := getSchedulerCfg()
 	if err != nil {
 		return nil, xerrors.Errorf("get SchedulerCfg: %w", err)
@@ -47,6 +50,7 @@ func NewConfig() (*Config, error) {
 
 	return &Config{
 		Port:                port,
+		ApiUrl:              apiurl,
 		EtcdURL:             etcdurl,
 		FrontendURL:         frontendurl,
 		InitialSchedulerCfg: initialschedulerCfg,
@@ -65,6 +69,21 @@ func getPort() (int, error) {
 		return 0, xerrors.Errorf("convert PORT of string to int: %w", err)
 	}
 	return port, nil
+}
+
+func getAPIURL() string {
+	p := os.Getenv("KUBE_API_PORT")
+	if p == "" {
+		// we still want the simulator to behave as before,
+		// use a local test port.
+		p = "0"
+	}
+
+	h := os.Getenv("KUBE_API_HOST")
+	if h == "" {
+		h = "127.0.0.1"
+	}
+	return h + ":" + p
 }
 
 func getEtcdURL() (string, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ var ErrEmptyEnv = errors.New("env is needed, but empty")
 // Config is configuration for simulator.
 type Config struct {
 	Port                int
-	APIURL              string
+	KubeAPIServerURL    string
 	EtcdURL             string
 	FrontendURL         string
 	InitialSchedulerCfg *v1beta2config.KubeSchedulerConfiguration
@@ -41,7 +41,7 @@ func NewConfig() (*Config, error) {
 		return nil, xerrors.Errorf("get frontend URL: %w", err)
 	}
 
-	apiurl := getAPIURL()
+	apiurl := getKubeAPIServerURL()
 
 	initialschedulerCfg, err := getSchedulerCfg()
 	if err != nil {
@@ -50,7 +50,7 @@ func NewConfig() (*Config, error) {
 
 	return &Config{
 		Port:                port,
-		APIURL:              apiurl,
+		KubeAPIServerURL:    apiurl,
 		EtcdURL:             etcdurl,
 		FrontendURL:         frontendurl,
 		InitialSchedulerCfg: initialschedulerCfg,
@@ -71,7 +71,7 @@ func getPort() (int, error) {
 	return port, nil
 }
 
-func getAPIURL() string {
+func getKubeAPIServerURL() string {
 	p := os.Getenv("KUBE_API_PORT")
 	if p == "" {
 		// we still want the simulator to behave as before,

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ var ErrEmptyEnv = errors.New("env is needed, but empty")
 // Config is configuration for simulator.
 type Config struct {
 	Port                int
-	ApiUrl              string
+	APIURL              string
 	EtcdURL             string
 	FrontendURL         string
 	InitialSchedulerCfg *v1beta2config.KubeSchedulerConfiguration
@@ -50,7 +50,7 @@ func NewConfig() (*Config, error) {
 
 	return &Config{
 		Port:                port,
-		ApiUrl:              apiurl,
+		APIURL:              apiurl,
 		EtcdURL:             etcdurl,
 		FrontendURL:         frontendurl,
 		InitialSchedulerCfg: initialschedulerCfg,

--- a/k8sapiserver/k8sapiserver.go
+++ b/k8sapiserver/k8sapiserver.go
@@ -40,14 +40,14 @@ import (
 )
 
 // StartAPIServer starts API server, and it make panic when a error happen.
-func StartAPIServer(apiURL string, etcdURL string) (*restclient.Config, func(), error) {
+func StartAPIServer(kubeAPIServerURL string, etcdURL string) (*restclient.Config, func(), error) {
 	h := &APIServerHolder{Initialized: make(chan struct{})}
 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		<-h.Initialized
 		h.M.GenericAPIServer.Handler.ServeHTTP(w, req)
 	})
 
-	l, err := net.Listen("tcp", apiURL)
+	l, err := net.Listen("tcp", kubeAPIServerURL)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("announces on the local network address: %w", err)
 	}

--- a/k8sapiserver/k8sapiserver.go
+++ b/k8sapiserver/k8sapiserver.go
@@ -49,7 +49,7 @@ func StartAPIServer(apiURL string, etcdURL string) (*restclient.Config, func(), 
 
 	l, err := net.Listen("tcp", apiURL)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("Address already in used: %w", err)
+		return nil, nil, xerrors.Errorf("announces on the local network address: %w", err)
 	}
 
 	s := &httptest.Server{
@@ -59,7 +59,7 @@ func StartAPIServer(apiURL string, etcdURL string) (*restclient.Config, func(), 
 		},
 	}
 	s.Start()
-	klog.Info("Http serving on:", s.URL)
+	klog.Info("kube-apiserver is started on :", s.URL)
 
 	c := NewControlPlaneConfigWithOptions(s.URL, etcdURL)
 

--- a/simulator.go
+++ b/simulator.go
@@ -30,7 +30,7 @@ func startSimulator() error {
 		return xerrors.Errorf("get config: %w", err)
 	}
 
-	restclientCfg, apiShutdown, err := k8sapiserver.StartAPIServer(cfg.APIURL, cfg.EtcdURL)
+	restclientCfg, apiShutdown, err := k8sapiserver.StartAPIServer(cfg.KubeAPIServerURL, cfg.EtcdURL)
 	if err != nil {
 		return xerrors.Errorf("start API server: %w", err)
 	}

--- a/simulator.go
+++ b/simulator.go
@@ -30,7 +30,7 @@ func startSimulator() error {
 		return xerrors.Errorf("get config: %w", err)
 	}
 
-	restclientCfg, apiShutdown, err := k8sapiserver.StartAPIServer(cfg.ApiUrl, cfg.EtcdURL)
+	restclientCfg, apiShutdown, err := k8sapiserver.StartAPIServer(cfg.APIURL, cfg.EtcdURL)
 	if err != nil {
 		return xerrors.Errorf("start API server: %w", err)
 	}

--- a/simulator.go
+++ b/simulator.go
@@ -30,7 +30,7 @@ func startSimulator() error {
 		return xerrors.Errorf("get config: %w", err)
 	}
 
-	restclientCfg, apiShutdown, err := k8sapiserver.StartAPIServer(cfg.EtcdURL)
+	restclientCfg, apiShutdown, err := k8sapiserver.StartAPIServer(cfg.ApiUrl, cfg.EtcdURL)
 	if err != nil {
 		return xerrors.Errorf("start API server: %w", err)
 	}


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature #55 
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR addresses the feature request #55 , it allows user to use kubectl to interact with the API server by specifying the --server flag pointed to the opened port.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
N/A

#### Special notes for your reviewer:


/label tide/merge-method-squash
