### PR TITLE
Disable the delete button when the selected `priorityclass` is the system one

### DIFF
--- a/web/components/ResourceBar/ResourceBar.vue
+++ b/web/components/ResourceBar/ResourceBar.vue
@@ -16,7 +16,7 @@
           editmode = !editmode;
         }
       "
-      :enable-delete-btn="selected && !selected.isNew"
+      :enable-delete-btn="selected && !selected.isNew && selected.isDeletable"
       :enable-editmode-switch="selected && !selected.isNew"
     />
 
@@ -90,6 +90,7 @@ interface SelectedItem {
   isNew: boolean;
   item: Resource;
   resourceKind: string;
+  isDeletable: boolean;
 }
 
 export default defineComponent({

--- a/web/store/node.ts
+++ b/web/store/node.ts
@@ -40,7 +40,7 @@ export default function nodeStore() {
           isNew: isNew,
           item: n,
           resourceKind: "Node",
-          isDeletable: false,
+          isDeletable: true,
         };
       }
     },

--- a/web/store/node.ts
+++ b/web/store/node.ts
@@ -12,6 +12,7 @@ type selectedNode = {
   isNew: boolean;
   item: V1Node;
   resourceKind: string;
+  isDeletable: boolean;
 };
 
 export default function nodeStore() {
@@ -39,6 +40,7 @@ export default function nodeStore() {
           isNew: isNew,
           item: n,
           resourceKind: "Node",
+          isDeletable: false,
         };
       }
     },

--- a/web/store/pod.ts
+++ b/web/store/pod.ts
@@ -15,6 +15,7 @@ export type SelectedPod = {
   isNew: boolean;
   item: V1Pod;
   resourceKind: string;
+  isDeletable: boolean;
 };
 
 export default function podStore() {
@@ -46,6 +47,7 @@ export default function podStore() {
           isNew: isNew,
           item: p,
           resourceKind: "Pod",
+          isDeletable: true,
         };
       }
     },

--- a/web/store/priorityclass.ts
+++ b/web/store/priorityclass.ts
@@ -26,6 +26,13 @@ export default function priorityclassStore() {
     priorityclasses: [],
   });
 
+  // `CheckIsDeletable` is to return whether this PriorityClass can be deleted.
+  // The name of it prefixed with `system-` is reserved by the system
+  // and it can't be deleted.
+  const checkIsDeletable = (n: V1PriorityClass) => {
+    return !!n.metadata?.name && !n.metadata?.name?.startsWith("system-");
+  };
+
   return {
     get priorityclasses() {
       return state.priorityclasses;
@@ -45,7 +52,7 @@ export default function priorityclassStore() {
           isNew: isNew,
           item: n,
           resourceKind: "PC",
-          isDeletable: true,
+          isDeletable: checkIsDeletable(n),
         };
       }
     },

--- a/web/store/priorityclass.ts
+++ b/web/store/priorityclass.ts
@@ -26,9 +26,8 @@ export default function priorityclassStore() {
     priorityclasses: [],
   });
 
-  // `CheckIsDeletable` is to return whether this PriorityClass can be deleted.
-  // The name of it prefixed with `system-` is reserved by the system
-  // and it can't be deleted.
+  // `CheckIsDeletable` returns whether the given PriorityClass can be deleted or not.
+  // The PriorityClasses that have the name prefixed with `system-` are reserved by the system so can't be deleted.
   const checkIsDeletable = (n: V1PriorityClass) => {
     return !!n.metadata?.name && !n.metadata?.name?.startsWith("system-");
   };

--- a/web/store/priorityclass.ts
+++ b/web/store/priorityclass.ts
@@ -17,6 +17,7 @@ type selectedPriorityClass = {
   isNew: boolean;
   item: V1PriorityClass;
   resourceKind: string;
+  isDeletable: boolean;
 };
 
 export default function priorityclassStore() {
@@ -44,6 +45,7 @@ export default function priorityclassStore() {
           isNew: isNew,
           item: n,
           resourceKind: "PC",
+          isDeletable: true,
         };
       }
     },

--- a/web/store/pv.ts
+++ b/web/store/pv.ts
@@ -17,6 +17,7 @@ type selectedPersistentVolume = {
   isNew: boolean;
   item: V1PersistentVolume;
   resourceKind: string;
+  isDeletable: boolean;
 };
 
 export default function pvStore() {
@@ -44,6 +45,7 @@ export default function pvStore() {
           isNew: isNew,
           item: p,
           resourceKind: "PV",
+          isDeletable: true,
         };
       }
     },

--- a/web/store/pvc.ts
+++ b/web/store/pvc.ts
@@ -17,6 +17,7 @@ type selectedPersistentVolumeClaim = {
   isNew: boolean;
   item: V1PersistentVolumeClaim;
   resourceKind: string;
+  isDeletable: boolean;
 };
 
 export default function pvcStore() {
@@ -44,6 +45,7 @@ export default function pvcStore() {
           isNew: isNew,
           item: n,
           resourceKind: "PVC",
+          isDeletable: true,
         };
       }
     },

--- a/web/store/schedulerconfiguration.ts
+++ b/web/store/schedulerconfiguration.ts
@@ -14,6 +14,7 @@ type selectedConfig = {
   isNew: boolean;
   item: SchedulerConfiguration;
   resourceKind: string;
+  isDeletable: boolean;
 };
 
 export default function schedulerconfigurationStore() {
@@ -42,6 +43,7 @@ export default function schedulerconfigurationStore() {
           isNew: true,
           item: c,
           resourceKind: "SchedulerConfiguration",
+          isDeletable: true,
         };
       }
     },

--- a/web/store/storageclass.ts
+++ b/web/store/storageclass.ts
@@ -17,6 +17,7 @@ type selectedStorageClass = {
   isNew: boolean;
   item: V1StorageClass;
   resourceKind: string;
+  isDeletable: boolean;
 };
 
 export default function storageclassStore() {
@@ -44,6 +45,7 @@ export default function storageclassStore() {
           isNew: isNew,
           item: n,
           resourceKind: "SC",
+          isDeletable: true,
         };
       }
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:
We turn off the delete button when the selected `priorityclass` is created by k8s.
 - The name of it prefixed with `system-` is reserved by the system and it can't be deleted.
[Reference](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#how-to-use-priority-and-preemption)

To implement that logic, we added a new field on` SelectedItem` interface.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #99

#### Special notes for your reviewer:

For the general
<img width="1004" alt="スクリーンショット 2022-02-11 20 33 02" src="https://user-images.githubusercontent.com/22634362/153586072-025327f8-3532-4d4a-977d-7090d805216c.png">

For the system
<img width="992" alt="スクリーンショット 2022-02-11 20 32 42" src="https://user-images.githubusercontent.com/22634362/153586094-25b13c12-73f3-4ca0-b0db-20ef921cdb8e.png">

Even now, the apply/edit button is still enabled.
This is because even if the `PriorityClass` is the system one, `description` field, for example, is editable.

/label tide/merge-method-squash
