### PR TITLE
Fix race condition in store result map

### DIFF
--- a/scheduler/plugin/resultstore/store.go
+++ b/scheduler/plugin/resultstore/store.go
@@ -132,7 +132,7 @@ func (s *Store) addSchedulingResultToPod(_, newObj interface{}) {
 	}
 
 	// delete data from Store only if data is successfully added on pod's annotations.
-	s.DeleteData(k)
+	s.deleteData(k)
 }
 
 func (s *Store) addFilterResultToPod(pod *v1.Pod) error {
@@ -237,5 +237,9 @@ func (s *Store) applyWeightOnScore(pluginName string, score int64) int64 {
 func (s *Store) DeleteData(k key) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	s.deleteData(k)
+}
+
+func (s *Store) deleteData(k key) {
 	delete(s.results, k)
 }

--- a/scheduler/plugin/resultstore/store.go
+++ b/scheduler/plugin/resultstore/store.go
@@ -87,6 +87,8 @@ func newData() *result {
 }
 
 func (s *Store) addSchedulingResultToPod(_, newObj interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	ctx := context.Background()
 
 	pod, ok := newObj.(*v1.Pod)
@@ -233,5 +235,7 @@ func (s *Store) applyWeightOnScore(pluginName string, score int64) int64 {
 }
 
 func (s *Store) DeleteData(k key) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	delete(s.results, k)
 }

--- a/scheduler/plugin/resultstore/store.go
+++ b/scheduler/plugin/resultstore/store.go
@@ -240,6 +240,8 @@ func (s *Store) DeleteData(k key) {
 	s.deleteData(k)
 }
 
+// deleteData deletes the result stored with the given key.
+// Note: we assume the store lock is already acquired.
 func (s *Store) deleteData(k key) {
 	delete(s.results, k)
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Fixes a race condition in the Store struct located in the resultstore package

#### Which issue(s) this PR fixes:
There is no issue opened for this bug 

#### Special notes for your reviewer:
I've been using the simulator to test different scheduler configurations starting from a existing cluster status. In order to do that, I am mocking the status of the cluster in the simulator creating equivalent nodes in the original cluster and forcing pods to be placed in the same nodes. Since my clusters have a lot of nodes and pods, I've created some scripts to load the existing cluster and by doing this I've found out a race condition

#### Steps to reproduce
* Start the simulator (both bare metal and docker-compose version should work)
* Create a huge amount of pods in a short period of time. This script can be used to do that (https://gist.github.com/Ezetowers/35c2166f74d234710fe34048e09a3c21) or import an already exported simulation with a huge amount of nodes
* Repeat the past steps until the following error appears
```
fatal error: concurrent map read and map write

goroutine 5255 [running]:
runtime.throw({0x2774833, 0x20ef145})
        /opt/go/src/runtime/panic.go:1198 +0x71 fp=0xc004bd0b08 sp=0xc004bd0ad8 pc=0x437731
runtime.mapaccess2_faststr(0x23ce960, 0xc00bef6e10, {0xc008ec8b30, 0xf})
        /opt/go/src/runtime/map_faststr.go:116 +0x3d4 fp=0xc004bd0b70 sp=0xc004bd0b08 pc=0x414854
github.com/kubernetes-sigs/kube-scheduler-simulator/scheduler/plugin/resultstore.(*Store).AddFilterResult(0xc0082afb90, {0xc00bef6e10, 0xc007c35800}, {0xc00bef6e00, 0x7f14c98d43d8}, {0xc00aa0f924, 0x6}, {0x27526ec, 0x12}, {0x273e564, ...})
        /home/etorres/Development/kube-scheduler-simulator/scheduler/plugin/resultstore/store.go:175 +0x13c fp=0xc004bd0bf8 sp=0xc004bd0b70 pc=0x216631c
github.com/kubernetes-sigs/kube-scheduler-simulator/scheduler/plugin.(*simulatorPlugin).Filter(0xc001e34be0, {0x2bb2f90, 0xc0063ebf80}, 0xc0069dcdb0, 0xc007c35800, 0xc0097ff440)
        /home/etorres/Development/kube-scheduler-simulator/scheduler/plugin/plugins.go:323 +0x125 fp=0xc004bd0c88 sp=0xc004bd0bf8 pc=0x21694e5
k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*frameworkImpl).runFilterPlugin(0x8edccf, {0x2bb2f90, 0xc0063ebf80}, {0x7f14c1cff378, 0xc001e34be0}, 0x0, 0xc004bd0d18, 0xc004bd0d70)
        /home/etorres/go/pkg/mod/k8s.io/kubernetes@v1.22.0/pkg/scheduler/framework/runtime/framework.go:597 +0x167 fp=0xc004bd0d10 sp=0xc004bd0c88 pc=0x2105f47
k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*frameworkImpl).RunFilterPlugins(0xc00646f340, {0x2bb2f90, 0xc0063ebf80}, 0xc00646f340, 0xc007c35800, 0x4a1b1e)
        /home/etorres/go/pkg/mod/k8s.io/kubernetes@v1.22.0/pkg/scheduler/framework/runtime/framework.go:575 +0xf6 fp=0xc004bd0e08 sp=0xc004bd0d10 pc=0x2105a36
k8s.io/kubernetes/pkg/scheduler/framework/runtime.(*frameworkImpl).RunFilterPluginsWithNominatedPods(0x7f14f2dcfd28, {0x2bb2f90, 0xc0063ebf80}, 0xc00683de60, 0xc00506a528, 0xc0097ff440)
        /home/etorres/go/pkg/mod/k8s.io/kubernetes@v1.22.0/pkg/scheduler/framework/runtime/framework.go:683 +0x128 fp=0xc004bd0e98 sp=0xc004bd0e08 pc=0x21068e8
k8s.io/kubernetes/pkg/scheduler.(*genericScheduler).findNodesThatPassFilters.func1(0x0)
        /home/etorres/go/pkg/mod/k8s.io/kubernetes@v1.22.0/pkg/scheduler/generic_scheduler.go:296 +0xd1 fp=0xc004bd0f38 sp=0xc004bd0e98 pc=0x215d771
k8s.io/client-go/util/workqueue.ParallelizeUntil.func1()
        /home/etorres/go/pkg/mod/k8s.io/client-go@v0.22.0/util/workqueue/parallelizer.go:90 +0x150 fp=0xc004bd0fe0 sp=0xc004bd0f38 pc=0x1147c70
runtime.goexit()
        /opt/go/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc004bd0fe8 sp=0xc004bd0fe0 pc=0x46a9c1
created by k8s.io/client-go/util/workqueue.ParallelizeUntil
        /home/etorres/go/pkg/mod/k8s.io/client-go@v0.22.0/util/workqueue/parallelizer.go:76 +0x1dc

```

/label tide/merge-method-squash
