### PR TITLE
Remove `IgnoreErr` options from  the `Import/Export` function called via web API

### DIFF
--- a/export/export_test.go
+++ b/export/export_test.go
@@ -1080,7 +1080,7 @@ func TestService_Import(t *testing.T) {
 	}
 }
 
-func TestService_Import_WithEgnoreErrOption(t *testing.T) {
+func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name                     string

--- a/server/handler/export.go
+++ b/server/handler/export.go
@@ -35,7 +35,7 @@ func NewExportHandler(s di.ExportService) *ExportHandler {
 func (h *ExportHandler) Export(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	rs, err := h.service.Export(ctx, h.service.IgnoreErr())
+	rs, err := h.service.Export(ctx)
 	if err != nil {
 		klog.Errorf("failed to export all resources: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)
@@ -52,7 +52,7 @@ func (h *ExportHandler) Import(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest)
 	}
 
-	err := h.service.Import(ctx, convertToResourcesApplyConfiguration(reqResources), h.service.IgnoreErr())
+	err := h.service.Import(ctx, convertToResourcesApplyConfiguration(reqResources))
 	if err != nil {
 		klog.Errorf("failed to import all resources: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In #103, I have added the `IgnoreErr` option to the `Import/Export` functions called via web API.
But the `IgnoreErr` option was going to use for another logic (Only for Importing the existing Cluster's resources.)
When we call it via web API, it should return an error if an error has occurred.
Since the current usage of the function is incorrect, I fixed it.

And also, I found a typo in the test function's name.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #103

#### Special notes for your reviewer:

/label tide/merge-method-squash
