### PR TITLE
support namespace in each service

### DIFF
--- a/export/export.go
+++ b/export/export.go
@@ -61,7 +61,7 @@ type ResourcesForImport struct {
 }
 
 type PodService interface {
-	List(ctx context.Context, namespaace string) (*corev1.PodList, error)
+	List(ctx context.Context, namespace string) (*corev1.PodList, error)
 	Apply(ctx context.Context, pod *v1.PodApplyConfiguration, namespace string) (*corev1.Pod, error)
 }
 

--- a/export/export.go
+++ b/export/export.go
@@ -26,6 +26,11 @@ import (
 	"github.com/kubernetes-sigs/kube-scheduler-simulator/util"
 )
 
+const (
+	// TODO: this will remove soon in this PR.
+	defaultNamespaceName = "default"
+)
+
 type Service struct {
 	client               clientset.Interface
 	podService           PodService
@@ -60,8 +65,8 @@ type ResourcesForImport struct {
 }
 
 type PodService interface {
-	List(ctx context.Context) (*corev1.PodList, error)
-	Apply(ctx context.Context, pod *v1.PodApplyConfiguration) (*corev1.Pod, error)
+	List(ctx context.Context, namespaace string) (*corev1.PodList, error)
+	Apply(ctx context.Context, pod *v1.PodApplyConfiguration, namespace string) (*corev1.Pod, error)
 }
 
 type NodeService interface {
@@ -249,7 +254,7 @@ func (s *Service) listPods(ctx context.Context, r *ResourcesForExport, eg *util.
 	}
 	eg.Grp.Go(func() error {
 		defer eg.Sem.Release(1)
-		pods, err := s.podService.List(ctx)
+		pods, err := s.podService.List(ctx, defaultNamespaceName)
 		if err != nil {
 			if !opts.ignoreErr {
 				return xerrors.Errorf("call list pods: %w", err)
@@ -516,7 +521,7 @@ func (s *Service) applyPods(ctx context.Context, r *ResourcesForImport, eg *util
 		eg.Grp.Go(func() error {
 			defer eg.Sem.Release(1)
 			pod.ObjectMetaApplyConfiguration.UID = nil
-			_, err := s.podService.Apply(ctx, &pod)
+			_, err := s.podService.Apply(ctx, &pod, defaultNamespaceName)
 			if err != nil {
 				if !opts.ignoreErr {
 					return xerrors.Errorf("apply Pod: %w", err)

--- a/export/export.go
+++ b/export/export.go
@@ -62,7 +62,7 @@ type ResourcesForImport struct {
 
 type PodService interface {
 	List(ctx context.Context, namespace string) (*corev1.PodList, error)
-	Apply(ctx context.Context, pod *v1.PodApplyConfiguration, namespace string) (*corev1.Pod, error)
+	Apply(ctx context.Context, namespace string, pod *v1.PodApplyConfiguration) (*corev1.Pod, error)
 }
 
 type NodeService interface {
@@ -78,7 +78,7 @@ type PersistentVolumeService interface {
 type PersistentVolumeClaimService interface {
 	Get(ctx context.Context, name string, namespace string) (*corev1.PersistentVolumeClaim, error)
 	List(ctx context.Context, namespace string) (*corev1.PersistentVolumeClaimList, error)
-	Apply(ctx context.Context, persistentVolumeClaime *v1.PersistentVolumeClaimApplyConfiguration, namespace string) (*corev1.PersistentVolumeClaim, error)
+	Apply(ctx context.Context, namespace string, persistentVolumeClaime *v1.PersistentVolumeClaimApplyConfiguration) (*corev1.PersistentVolumeClaim, error)
 }
 
 type StorageClassService interface {
@@ -439,7 +439,7 @@ func (s *Service) applyPvcs(ctx context.Context, r *ResourcesForImport, eg *util
 		eg.Grp.Go(func() error {
 			defer eg.Sem.Release(1)
 			pvc.ObjectMetaApplyConfiguration.UID = nil
-			_, err := s.pvcService.Apply(ctx, &pvc, *pvc.Namespace)
+			_, err := s.pvcService.Apply(ctx, *pvc.Namespace, &pvc)
 			if err != nil {
 				if !opts.ignoreErr {
 					return xerrors.Errorf("apply PersistentVolumeClaims: %w", err)
@@ -517,7 +517,7 @@ func (s *Service) applyPods(ctx context.Context, r *ResourcesForImport, eg *util
 		eg.Grp.Go(func() error {
 			defer eg.Sem.Release(1)
 			pod.ObjectMetaApplyConfiguration.UID = nil
-			_, err := s.podService.Apply(ctx, &pod, *pod.Namespace)
+			_, err := s.podService.Apply(ctx, *pod.Namespace, &pod)
 			if err != nil {
 				if !opts.ignoreErr {
 					return xerrors.Errorf("apply Pod: %w", err)

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -25,6 +25,11 @@ import (
 	"github.com/kubernetes-sigs/kube-scheduler-simulator/util"
 )
 
+const (
+	testDefaultNamespaceName1 = "default1"
+	testDefaultNamespaceName2 = "default2"
+)
+
 func TestService_Export(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -37,10 +42,10 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export all resources",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -64,10 +69,10 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of PodService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("list pods"))
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("list pods"))
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -82,10 +87,10 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of NodeService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list nodes"))
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -100,10 +105,10 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of PersistentVolumeService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumes"))
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -118,10 +123,10 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of PersistentVolumeClaims",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -136,10 +141,10 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of storageClasses",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list storageClasses"))
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -154,10 +159,10 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of priorityClasses",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list priorityClasses"))
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -168,6 +173,115 @@ func TestService_Export(t *testing.T) {
 			},
 			wantReturn: nil,
 			wantErr:    true,
+		},
+		{
+			name: "export all pods with different namespaces",
+			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testDefaultNamespaceName1},
+						Spec:       corev1.PodSpec{NodeName: "node1"},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: testDefaultNamespaceName2},
+						Spec:       corev1.PodSpec{NodeName: "node2"},
+					},
+				}}, nil)
+				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
+				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
+				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+			},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				// add test data.
+				return c
+			},
+			wantReturn: &ResourcesForExport{
+				Pods: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testDefaultNamespaceName1},
+						Spec:       corev1.PodSpec{NodeName: "node1"},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: testDefaultNamespaceName2},
+						Spec:       corev1.PodSpec{NodeName: "node2"},
+					},
+				},
+				Nodes:           []corev1.Node{},
+				Pvs:             []corev1.PersistentVolume{},
+				Pvcs:            []corev1.PersistentVolumeClaim{},
+				StorageClasses:  []storagev1.StorageClass{},
+				PriorityClasses: []schedulingv1.PriorityClass{},
+				SchedulerConfig: &v1beta2config.KubeSchedulerConfiguration{},
+			},
+		},
+		{
+			name: "export all pvcs with different namespaces",
+			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
+				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc1",
+							Namespace: testDefaultNamespaceName1,
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pv1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc2",
+							Namespace: testDefaultNamespaceName2,
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pv2",
+						},
+					},
+				}}, nil)
+				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
+				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+			},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				// add test data.
+				return c
+			},
+			wantReturn: &ResourcesForExport{
+				Pods:  []corev1.Pod{},
+				Nodes: []corev1.Node{},
+				Pvs:   []corev1.PersistentVolume{},
+				Pvcs: []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc1",
+							Namespace: testDefaultNamespaceName1,
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pv1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc2",
+							Namespace: testDefaultNamespaceName2,
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pv2",
+						},
+					},
+				},
+				StorageClasses:  []storagev1.StorageClass{},
+				PriorityClasses: []schedulingv1.PriorityClass{},
+				SchedulerConfig: &v1beta2config.KubeSchedulerConfiguration{},
+			},
+			wantErr: false,
 		},
 	}
 	for _, tt := range tests {
@@ -209,10 +323,10 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "export all resources",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -236,10 +350,10 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failure on List of PodService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("list pods"))
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("list pods"))
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -262,10 +376,10 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on List of NodeService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list nodes"))
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -288,10 +402,10 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on List of PersistentVolumeService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumes"))
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -314,10 +428,10 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on List of PersistentVolumeClaims",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -340,10 +454,10 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on List of storageClasses",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list storageClasses"))
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -366,10 +480,10 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on List of priorityClasses",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list priorityClasses"))
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -429,7 +543,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import all success",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -438,8 +552,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -483,15 +597,15 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on Pod Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("apply pod"))
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply pod"))
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
 					assert.Equal(t, "Node1", *cfg.Name)
 				})
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -535,15 +649,15 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on Node Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply node"))
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -587,15 +701,15 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on PersistentVolume Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
 					assert.Equal(t, "Node1", *cfg.Name)
 				})
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply PersistentVolume"))
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -639,7 +753,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on PersistentVolumeClaim Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -648,8 +762,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("apply PersistentVolumeClaim"))
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply PersistentVolumeClaim"))
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
 					assert.Equal(t, "StorageClass1", *cfg.Name)
 				})
@@ -691,7 +805,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on StorageClass Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -700,8 +814,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply StorageClass"))
@@ -743,7 +857,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on PriorityClass Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -752,8 +866,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -795,7 +909,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import success when PersistentVolumeClaim was not found (Get() return err)",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -804,8 +918,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), "PVC1", defaultNamespaceName).Return(nil, xerrors.Errorf("get persistentVolumeClaim"))
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), "PVC1", gomock.Any()).Return(nil, xerrors.Errorf("get persistentVolumeClaim"))
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -825,7 +939,7 @@ func TestService_Import(t *testing.T) {
 				pcs := []schedulingcfgv1.PriorityClassApplyConfiguration{}
 				pods = append(pods, *v1.Pod("Pod1", "default"))
 				nodes = append(nodes, *v1.Node("Node1"))
-				pvs = append(pvs, *v1.PersistentVolume("PV1").WithStatus(v1.PersistentVolumeStatus().WithPhase("Bound")).WithSpec(v1.PersistentVolumeSpec().WithClaimRef(v1.ObjectReference().WithName("PVC1"))))
+				pvs = append(pvs, *v1.PersistentVolume("PV1").WithStatus(v1.PersistentVolumeStatus().WithPhase("Bound")).WithSpec(v1.PersistentVolumeSpec().WithClaimRef(v1.ObjectReference().WithName("PVC1").WithNamespace("default"))))
 				pvcs = append(pvcs, *v1.PersistentVolumeClaim("PVC1", "default"))
 				storageclasses = append(storageclasses, *confstoragev1.StorageClass("StorageClass1"))
 				pcs = append(pcs, *schedulingcfgv1.PriorityClass("PriorityClass1"))
@@ -849,7 +963,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import success when PersistentVolumeClaim was found (Get() return err)",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -858,8 +972,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -879,7 +993,7 @@ func TestService_Import(t *testing.T) {
 				pcs := []schedulingcfgv1.PriorityClassApplyConfiguration{}
 				pods = append(pods, *v1.Pod("Pod1", "default"))
 				nodes = append(nodes, *v1.Node("Node1"))
-				pvs = append(pvs, *v1.PersistentVolume("PV1").WithStatus(v1.PersistentVolumeStatus().WithPhase("Bound")).WithSpec(v1.PersistentVolumeSpec().WithClaimRef(v1.ObjectReference().WithName("PVC1"))))
+				pvs = append(pvs, *v1.PersistentVolume("PV1").WithStatus(v1.PersistentVolumeStatus().WithPhase("Bound")).WithSpec(v1.PersistentVolumeSpec().WithClaimRef(v1.ObjectReference().WithName("PVC1").WithNamespace("default"))))
 				pvcs = append(pvcs, *v1.PersistentVolumeClaim("PVC1", "default"))
 				storageclasses = append(storageclasses, *confstoragev1.StorageClass("StorageClass1"))
 				pcs = append(pcs, *schedulingcfgv1.PriorityClass("PriorityClass1"))
@@ -903,19 +1017,19 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "PV be related with PVC and assign UID",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 					assert.Equal(t, "PVC1", *cfg.Spec.ClaimRef.Name)
 					assert.Equal(t, "testUID", string(*cfg.Spec.ClaimRef.UID))
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						UID: "testUID",
 					},
 				}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
 				pcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&schedulingv1.PriorityClass{}, nil)
 				schedulers.EXPECT().RestartScheduler(gomock.Any()).Return(nil)
@@ -929,7 +1043,7 @@ func TestService_Import(t *testing.T) {
 				pcs := []schedulingcfgv1.PriorityClassApplyConfiguration{}
 				pods = append(pods, *v1.Pod("Pod1", "default"))
 				nodes = append(nodes, *v1.Node("Node1"))
-				pvs = append(pvs, *v1.PersistentVolume("PV1").WithStatus(v1.PersistentVolumeStatus().WithPhase("Bound")).WithSpec(v1.PersistentVolumeSpec().WithClaimRef(v1.ObjectReference().WithName("PVC1"))))
+				pvs = append(pvs, *v1.PersistentVolume("PV1").WithStatus(v1.PersistentVolumeStatus().WithPhase("Bound")).WithSpec(v1.PersistentVolumeSpec().WithClaimRef(v1.ObjectReference().WithName("PVC1").WithNamespace("default"))))
 				pvcs = append(pvcs, *v1.PersistentVolumeClaim("PVC1", "default"))
 				storageclasses = append(storageclasses, *confstoragev1.StorageClass("StorageClass1"))
 				pcs = append(pcs, *schedulingcfgv1.PriorityClass("PriorityClass1"))
@@ -953,14 +1067,14 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "success import pv and pvc from json string (UID be set to nil)",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "pv1", *cfg.Name)
 					assert.Empty(t, cfg.ObjectMetaApplyConfiguration.UID)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "pvc1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
@@ -987,14 +1101,14 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "success import when pv.Status is not exist",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "pv1", *cfg.Name)
 					assert.Empty(t, cfg.Status)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "pvc1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
@@ -1022,14 +1136,14 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "success import when pv.Status.Phase is not exist",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "pv1", *cfg.Name)
 					assert.Empty(t, cfg.Status.Phase)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "pvc1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
@@ -1047,6 +1161,122 @@ func TestService_Import(t *testing.T) {
 					panic(err)
 				}
 				return &r
+			},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				return c
+			},
+			wantErr: false,
+		},
+		{
+			name: "import all pods with different namespaces",
+			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), testDefaultNamespaceName1).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+					assert.Equal(t, "Pod1", *cfg.Name)
+				})
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), testDefaultNamespaceName2).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+					assert.Equal(t, "Pod2", *cfg.Name)
+				})
+				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
+					assert.Equal(t, "Node1", *cfg.Name)
+				})
+				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
+					assert.Equal(t, "PV1", *cfg.Name)
+				})
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+					assert.Equal(t, "PVC1", *cfg.Name)
+				})
+				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
+					assert.Equal(t, "StorageClass1", *cfg.Name)
+				})
+				pcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&schedulingv1.PriorityClass{}, nil).Do(func(_ context.Context, cfg *schedulingcfgv1.PriorityClassApplyConfiguration) {
+					assert.Equal(t, "PriorityClass1", *cfg.Name)
+				})
+				schedulers.EXPECT().RestartScheduler(gomock.Any()).Return(nil)
+			},
+			applyConfiguration: func() *ResourcesForImport {
+				pods := []v1.PodApplyConfiguration{}
+				nodes := []v1.NodeApplyConfiguration{}
+				pvs := []v1.PersistentVolumeApplyConfiguration{}
+				pvcs := []v1.PersistentVolumeClaimApplyConfiguration{}
+				storageclasses := []confstoragev1.StorageClassApplyConfiguration{}
+				pcs := []schedulingcfgv1.PriorityClassApplyConfiguration{}
+				pods = append(pods, *v1.Pod("Pod1", testDefaultNamespaceName1))
+				pods = append(pods, *v1.Pod("Pod2", testDefaultNamespaceName2))
+				nodes = append(nodes, *v1.Node("Node1"))
+				pvs = append(pvs, *v1.PersistentVolume("PV1").WithStatus(v1.PersistentVolumeStatus().WithPhase("Pending")).WithUID("test"))
+				pvcs = append(pvcs, *v1.PersistentVolumeClaim("PVC1", "default"))
+				storageclasses = append(storageclasses, *confstoragev1.StorageClass("StorageClass1"))
+				pcs = append(pcs, *schedulingcfgv1.PriorityClass("PriorityClass1"))
+				config, _ := schedulerCfg.DefaultSchedulerConfig()
+				return &ResourcesForImport{
+					Pods:            pods,
+					Nodes:           nodes,
+					Pvs:             pvs,
+					Pvcs:            pvcs,
+					StorageClasses:  storageclasses,
+					PriorityClasses: pcs,
+					SchedulerConfig: config,
+				}
+			},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				return c
+			},
+			wantErr: false,
+		},
+		{
+			name: "import all pvcs with different namespaces",
+			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+					assert.Equal(t, "Pod1", *cfg.Name)
+				})
+				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
+					assert.Equal(t, "Node1", *cfg.Name)
+				})
+				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
+					assert.Equal(t, "PV1", *cfg.Name)
+				})
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), testDefaultNamespaceName1).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+					assert.Equal(t, "PVC1", *cfg.Name)
+				})
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), testDefaultNamespaceName2).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+					assert.Equal(t, "PVC2", *cfg.Name)
+				})
+				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
+					assert.Equal(t, "StorageClass1", *cfg.Name)
+				})
+				pcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&schedulingv1.PriorityClass{}, nil).Do(func(_ context.Context, cfg *schedulingcfgv1.PriorityClassApplyConfiguration) {
+					assert.Equal(t, "PriorityClass1", *cfg.Name)
+				})
+				schedulers.EXPECT().RestartScheduler(gomock.Any()).Return(nil)
+			},
+			applyConfiguration: func() *ResourcesForImport {
+				pods := []v1.PodApplyConfiguration{}
+				nodes := []v1.NodeApplyConfiguration{}
+				pvs := []v1.PersistentVolumeApplyConfiguration{}
+				pvcs := []v1.PersistentVolumeClaimApplyConfiguration{}
+				storageclasses := []confstoragev1.StorageClassApplyConfiguration{}
+				pcs := []schedulingcfgv1.PriorityClassApplyConfiguration{}
+				pods = append(pods, *v1.Pod("Pod1", "default"))
+				nodes = append(nodes, *v1.Node("Node1"))
+				pvs = append(pvs, *v1.PersistentVolume("PV1").WithStatus(v1.PersistentVolumeStatus().WithPhase("Pending")).WithUID("test"))
+				pvcs = append(pvcs, *v1.PersistentVolumeClaim("PVC1", testDefaultNamespaceName1))
+				pvcs = append(pvcs, *v1.PersistentVolumeClaim("PVC2", testDefaultNamespaceName2))
+				storageclasses = append(storageclasses, *confstoragev1.StorageClass("StorageClass1"))
+				pcs = append(pcs, *schedulingcfgv1.PriorityClass("PriorityClass1"))
+				config, _ := schedulerCfg.DefaultSchedulerConfig()
+				return &ResourcesForImport{
+					Pods:            pods,
+					Nodes:           nodes,
+					Pvs:             pvs,
+					Pvcs:            pvcs,
+					StorageClasses:  storageclasses,
+					PriorityClasses: pcs,
+					SchedulerConfig: config,
+				}
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -1092,7 +1322,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "import all success",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1101,8 +1331,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1146,15 +1376,15 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failure on Apply of Pod",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("apply pod"))
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply pod"))
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
 					assert.Equal(t, "Node1", *cfg.Name)
 				})
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1198,15 +1428,15 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of Node",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply node"))
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1250,15 +1480,15 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of PersistentVolume",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
 					assert.Equal(t, "Node1", *cfg.Name)
 				})
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply PersistentVolume"))
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1302,7 +1532,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of PersistentVolumeClaim",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1311,8 +1541,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("apply PersistentVolumeClaim"))
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply PersistentVolumeClaim"))
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
 					assert.Equal(t, "StorageClass1", *cfg.Name)
 				})
@@ -1354,7 +1584,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of StorageClass",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1363,8 +1593,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply StorageClass"))
@@ -1406,7 +1636,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of PriorityClass",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1415,8 +1645,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1659,11 +1889,11 @@ func TestService_Import_WithIgnoreSchedulerConfigurationOption(t *testing.T) {
 		{
 			name: "Import does not call RestartScheduler",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil)
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
 				pcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&schedulingv1.PriorityClass{}, nil)
 				// If the Import function call this, it will return the error.

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -40,7 +40,7 @@ func TestService_Export(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -67,7 +67,7 @@ func TestService_Export(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("list pods"))
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -85,7 +85,7 @@ func TestService_Export(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list nodes"))
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -103,7 +103,7 @@ func TestService_Export(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumes"))
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -121,7 +121,7 @@ func TestService_Export(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -139,7 +139,7 @@ func TestService_Export(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list storageClasses"))
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -157,7 +157,7 @@ func TestService_Export(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list priorityClasses"))
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -212,7 +212,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -239,7 +239,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("list pods"))
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -265,7 +265,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list nodes"))
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -291,7 +291,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumes"))
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -317,7 +317,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -343,7 +343,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list storageClasses"))
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -369,7 +369,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
-				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list priorityClasses"))
 				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
@@ -438,8 +438,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -490,8 +490,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -542,8 +542,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -594,8 +594,8 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "Node1", *cfg.Name)
 				})
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply PersistentVolume"))
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -648,8 +648,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply PersistentVolumeClaim"))
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("apply PersistentVolumeClaim"))
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
 					assert.Equal(t, "StorageClass1", *cfg.Name)
 				})
@@ -700,8 +700,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply StorageClass"))
@@ -752,8 +752,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -804,8 +804,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), "PVC1").Return(nil, xerrors.Errorf("get persistentVolumeClaim"))
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), "PVC1", defaultNamespaceName).Return(nil, xerrors.Errorf("get persistentVolumeClaim"))
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -858,8 +858,8 @@ func TestService_Import(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -910,12 +910,12 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PVC1", *cfg.Spec.ClaimRef.Name)
 					assert.Equal(t, "testUID", string(*cfg.Spec.ClaimRef.UID))
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{
 					ObjectMeta: metav1.ObjectMeta{
 						UID: "testUID",
 					},
 				}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
 				pcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&schedulingv1.PriorityClass{}, nil)
 				schedulers.EXPECT().RestartScheduler(gomock.Any()).Return(nil)
@@ -959,8 +959,8 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "pv1", *cfg.Name)
 					assert.Empty(t, cfg.ObjectMetaApplyConfiguration.UID)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "pvc1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
@@ -993,8 +993,8 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "pv1", *cfg.Name)
 					assert.Empty(t, cfg.Status)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "pvc1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
@@ -1028,8 +1028,8 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "pv1", *cfg.Name)
 					assert.Empty(t, cfg.Status.Phase)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "pvc1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
@@ -1101,8 +1101,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1153,8 +1153,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1205,8 +1205,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1257,8 +1257,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 					assert.Equal(t, "Node1", *cfg.Name)
 				})
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply PersistentVolume"))
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1311,8 +1311,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply PersistentVolumeClaim"))
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("apply PersistentVolumeClaim"))
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
 					assert.Equal(t, "StorageClass1", *cfg.Name)
 				})
@@ -1363,8 +1363,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply StorageClass"))
@@ -1415,8 +1415,8 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1662,8 +1662,8 @@ func TestService_Import_WithIgnoreSchedulerConfigurationOption(t *testing.T) {
 				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil)
-				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.PersistentVolumeClaim{}, nil)
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
 				pcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&schedulingv1.PriorityClass{}, nil)
 				// If the Import function call this, it will return the error.

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -543,7 +543,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import all success",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -553,7 +553,7 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -605,7 +605,7 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -649,7 +649,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on Node Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply node"))
@@ -657,7 +657,7 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -701,7 +701,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on PersistentVolume Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -709,7 +709,7 @@ func TestService_Import(t *testing.T) {
 				})
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply PersistentVolume"))
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -753,7 +753,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on PersistentVolumeClaim Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -805,7 +805,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on StorageClass Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -815,7 +815,7 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply StorageClass"))
@@ -857,7 +857,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on PriorityClass Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -867,7 +867,7 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -909,7 +909,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import success when PersistentVolumeClaim was not found (Get() return err)",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -919,7 +919,7 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), "PVC1", gomock.Any()).Return(nil, xerrors.Errorf("get persistentVolumeClaim"))
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -963,7 +963,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import success when PersistentVolumeClaim was found (Get() return err)",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -973,7 +973,7 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1074,7 +1074,7 @@ func TestService_Import(t *testing.T) {
 					assert.Empty(t, cfg.ObjectMetaApplyConfiguration.UID)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "pvc1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
@@ -1108,7 +1108,7 @@ func TestService_Import(t *testing.T) {
 					assert.Empty(t, cfg.Status)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "pvc1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
@@ -1143,7 +1143,7 @@ func TestService_Import(t *testing.T) {
 					assert.Empty(t, cfg.Status.Phase)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "pvc1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil)
@@ -1171,10 +1171,10 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import all pods with different namespaces",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), testDefaultNamespaceName1).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), testDefaultNamespaceName1, gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), testDefaultNamespaceName2).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), testDefaultNamespaceName2, gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod2", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1184,7 +1184,7 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1229,7 +1229,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import all pvcs with different namespaces",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1239,10 +1239,10 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), testDefaultNamespaceName1).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), testDefaultNamespaceName1, gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), testDefaultNamespaceName2).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), testDefaultNamespaceName2, gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC2", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1322,7 +1322,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "import all success",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1332,7 +1332,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1384,7 +1384,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1428,7 +1428,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of Node",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply node"))
@@ -1436,7 +1436,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1480,7 +1480,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of PersistentVolume",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1488,7 +1488,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 				})
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply PersistentVolume"))
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
@@ -1532,7 +1532,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of PersistentVolumeClaim",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1584,7 +1584,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of StorageClass",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1594,7 +1594,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply StorageClass"))
@@ -1636,7 +1636,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of PriorityClass",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1646,7 +1646,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 					assert.Equal(t, "PV1", *cfg.Name)
 				})
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)
-				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeClaimApplyConfiguration, namespace string) {
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
 					assert.Equal(t, "PVC1", *cfg.Name)
 				})
 				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {

--- a/export/export_test.go
+++ b/export/export_test.go
@@ -37,7 +37,7 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export all resources",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -64,7 +64,7 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of PodService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list pods"))
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("list pods"))
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -82,7 +82,7 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of NodeService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list nodes"))
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -100,7 +100,7 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of PersistentVolumeService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumes"))
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -118,7 +118,7 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of PersistentVolumeClaims",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
@@ -136,7 +136,7 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of storageClasses",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -154,7 +154,7 @@ func TestService_Export(t *testing.T) {
 		{
 			name: "export failure on List of priorityClasses",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -209,7 +209,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "export all resources",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -236,7 +236,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failure on List of PodService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list pods"))
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("list pods"))
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -262,7 +262,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on List of NodeService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list nodes"))
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -288,7 +288,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on List of PersistentVolumeService",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumes"))
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -314,7 +314,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on List of PersistentVolumeClaims",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
@@ -340,7 +340,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on List of storageClasses",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -366,7 +366,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on List of priorityClasses",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				pods.EXPECT().List(gomock.Any(), defaultNamespaceName).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
 				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
 				pvcs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
@@ -429,7 +429,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import all success",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -483,7 +483,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on Pod Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply pod"))
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("apply pod"))
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
 					assert.Equal(t, "Node1", *cfg.Name)
 				})
@@ -535,7 +535,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on Node Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply node"))
@@ -587,7 +587,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on PersistentVolume Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -639,7 +639,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on PersistentVolumeClaim Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -691,7 +691,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on StorageClass Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -743,7 +743,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import failure on PriorityClass Apply",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -795,7 +795,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import success when PersistentVolumeClaim was not found (Get() return err)",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -849,7 +849,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "import success when PersistentVolumeClaim was found (Get() return err)",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -903,7 +903,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "PV be related with PVC and assign UID",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil)
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "PV1", *cfg.Name)
@@ -953,7 +953,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "success import pv and pvc from json string (UID be set to nil)",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil)
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "pv1", *cfg.Name)
@@ -987,7 +987,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "success import when pv.Status is not exist",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil)
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "pv1", *cfg.Name)
@@ -1022,7 +1022,7 @@ func TestService_Import(t *testing.T) {
 		{
 			name: "success import when pv.Status.Phase is not exist",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil)
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
 					assert.Equal(t, "pv1", *cfg.Name)
@@ -1092,7 +1092,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "import all success",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1146,7 +1146,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failure on Apply of Pod",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply pod"))
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(nil, xerrors.Errorf("apply pod"))
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
 					assert.Equal(t, "Node1", *cfg.Name)
 				})
@@ -1198,7 +1198,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of Node",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("apply node"))
@@ -1250,7 +1250,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of PersistentVolume",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1302,7 +1302,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of PersistentVolumeClaim",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1354,7 +1354,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of StorageClass",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1406,7 +1406,7 @@ func TestService_Import_WithIgnoreErrOption(t *testing.T) {
 		{
 			name: "no error if failed on Apply of PriorityClass",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, cfg *v1.PodApplyConfiguration, ns string) {
 					assert.Equal(t, "Pod1", *cfg.Name)
 				})
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
@@ -1659,7 +1659,7 @@ func TestService_Import_WithIgnoreSchedulerConfigurationOption(t *testing.T) {
 		{
 			name: "Import does not call RestartScheduler",
 			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
-				pods.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil)
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), defaultNamespaceName).Return(&corev1.Pod{}, nil)
 				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil)
 				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil)
 				pvcs.EXPECT().Get(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil)

--- a/export/mock_export/pod.go
+++ b/export/mock_export/pod.go
@@ -36,7 +36,7 @@ func (m *MockPodService) EXPECT() *MockPodServiceMockRecorder {
 }
 
 // Apply mocks base method
-func (m *MockPodService) Apply(arg0 context.Context, arg1 *v10.PodApplyConfiguration, arg2 string) (*v1.Pod, error) {
+func (m *MockPodService) Apply(arg0 context.Context, arg1 string, arg2 *v10.PodApplyConfiguration) (*v1.Pod, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1.Pod)

--- a/export/mock_export/pod.go
+++ b/export/mock_export/pod.go
@@ -36,31 +36,31 @@ func (m *MockPodService) EXPECT() *MockPodServiceMockRecorder {
 }
 
 // Apply mocks base method
-func (m *MockPodService) Apply(arg0 context.Context, arg1 *v10.PodApplyConfiguration) (*v1.Pod, error) {
+func (m *MockPodService) Apply(arg0 context.Context, arg1 *v10.PodApplyConfiguration, arg2 string) (*v1.Pod, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply", arg0, arg1)
+	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1.Pod)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Apply indicates an expected call of Apply
-func (mr *MockPodServiceMockRecorder) Apply(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPodServiceMockRecorder) Apply(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockPodService)(nil).Apply), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockPodService)(nil).Apply), arg0, arg1, arg2)
 }
 
 // List mocks base method
-func (m *MockPodService) List(arg0 context.Context) (*v1.PodList, error) {
+func (m *MockPodService) List(arg0 context.Context, arg1 string) (*v1.PodList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0)
+	ret := m.ctrl.Call(m, "List", arg0, arg1)
 	ret0, _ := ret[0].(*v1.PodList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List
-func (mr *MockPodServiceMockRecorder) List(arg0 interface{}) *gomock.Call {
+func (mr *MockPodServiceMockRecorder) List(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPodService)(nil).List), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPodService)(nil).List), arg0, arg1)
 }

--- a/export/mock_export/pvc.go
+++ b/export/mock_export/pvc.go
@@ -36,7 +36,7 @@ func (m *MockPersistentVolumeClaimService) EXPECT() *MockPersistentVolumeClaimSe
 }
 
 // Apply mocks base method
-func (m *MockPersistentVolumeClaimService) Apply(arg0 context.Context, arg1 *v10.PersistentVolumeClaimApplyConfiguration, arg2 string) (*v1.PersistentVolumeClaim, error) {
+func (m *MockPersistentVolumeClaimService) Apply(arg0 context.Context, arg1 string, arg2 *v10.PersistentVolumeClaimApplyConfiguration) (*v1.PersistentVolumeClaim, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1.PersistentVolumeClaim)

--- a/export/mock_export/pvc.go
+++ b/export/mock_export/pvc.go
@@ -36,46 +36,46 @@ func (m *MockPersistentVolumeClaimService) EXPECT() *MockPersistentVolumeClaimSe
 }
 
 // Apply mocks base method
-func (m *MockPersistentVolumeClaimService) Apply(arg0 context.Context, arg1 *v10.PersistentVolumeClaimApplyConfiguration) (*v1.PersistentVolumeClaim, error) {
+func (m *MockPersistentVolumeClaimService) Apply(arg0 context.Context, arg1 *v10.PersistentVolumeClaimApplyConfiguration, arg2 string) (*v1.PersistentVolumeClaim, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Apply", arg0, arg1)
+	ret := m.ctrl.Call(m, "Apply", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1.PersistentVolumeClaim)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Apply indicates an expected call of Apply
-func (mr *MockPersistentVolumeClaimServiceMockRecorder) Apply(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPersistentVolumeClaimServiceMockRecorder) Apply(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockPersistentVolumeClaimService)(nil).Apply), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Apply", reflect.TypeOf((*MockPersistentVolumeClaimService)(nil).Apply), arg0, arg1, arg2)
 }
 
 // Get mocks base method
-func (m *MockPersistentVolumeClaimService) Get(arg0 context.Context, arg1 string) (*v1.PersistentVolumeClaim, error) {
+func (m *MockPersistentVolumeClaimService) Get(arg0 context.Context, arg1, arg2 string) (*v1.PersistentVolumeClaim, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1.PersistentVolumeClaim)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get
-func (mr *MockPersistentVolumeClaimServiceMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPersistentVolumeClaimServiceMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPersistentVolumeClaimService)(nil).Get), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockPersistentVolumeClaimService)(nil).Get), arg0, arg1, arg2)
 }
 
 // List mocks base method
-func (m *MockPersistentVolumeClaimService) List(arg0 context.Context) (*v1.PersistentVolumeClaimList, error) {
+func (m *MockPersistentVolumeClaimService) List(arg0 context.Context, arg1 string) (*v1.PersistentVolumeClaimList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0)
+	ret := m.ctrl.Call(m, "List", arg0, arg1)
 	ret0, _ := ret[0].(*v1.PersistentVolumeClaimList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List
-func (mr *MockPersistentVolumeClaimServiceMockRecorder) List(arg0 interface{}) *gomock.Call {
+func (mr *MockPersistentVolumeClaimServiceMockRecorder) List(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPersistentVolumeClaimService)(nil).List), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPersistentVolumeClaimService)(nil).List), arg0, arg1)
 }

--- a/node/mock_node/node.go
+++ b/node/mock_node/node.go
@@ -50,17 +50,17 @@ func (mr *MockPodServiceMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomo
 }
 
 // DeleteCollection mocks base method
-func (m *MockPodService) DeleteCollection(arg0 context.Context, arg1 v10.ListOptions) error {
+func (m *MockPodService) DeleteCollection(arg0 context.Context, arg1 string, arg2 v10.ListOptions) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCollection", arg0, arg1)
+	ret := m.ctrl.Call(m, "DeleteCollection", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteCollection indicates an expected call of DeleteCollection
-func (mr *MockPodServiceMockRecorder) DeleteCollection(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockPodServiceMockRecorder) DeleteCollection(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCollection", reflect.TypeOf((*MockPodService)(nil).DeleteCollection), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCollection", reflect.TypeOf((*MockPodService)(nil).DeleteCollection), arg0, arg1, arg2)
 }
 
 // List mocks base method

--- a/node/mock_node/node.go
+++ b/node/mock_node/node.go
@@ -6,51 +6,50 @@ package mock_node
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	v10 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	reflect "reflect"
 )
 
-// MockPodService is a mock of PodService interface.
+// MockPodService is a mock of PodService interface
 type MockPodService struct {
 	ctrl     *gomock.Controller
 	recorder *MockPodServiceMockRecorder
 }
 
-// MockPodServiceMockRecorder is the mock recorder for MockPodService.
+// MockPodServiceMockRecorder is the mock recorder for MockPodService
 type MockPodServiceMockRecorder struct {
 	mock *MockPodService
 }
 
-// NewMockPodService creates a new mock instance.
+// NewMockPodService creates a new mock instance
 func NewMockPodService(ctrl *gomock.Controller) *MockPodService {
 	mock := &MockPodService{ctrl: ctrl}
 	mock.recorder = &MockPodServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockPodService) EXPECT() *MockPodServiceMockRecorder {
 	return m.recorder
 }
 
-// Delete mocks base method.
-func (m *MockPodService) Delete(arg0 context.Context, arg1 string) error {
+// Delete mocks base method
+func (m *MockPodService) Delete(arg0 context.Context, arg1, arg2 string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// Delete indicates an expected call of Delete.
-func (mr *MockPodServiceMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
+// Delete indicates an expected call of Delete
+func (mr *MockPodServiceMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockPodService)(nil).Delete), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockPodService)(nil).Delete), arg0, arg1, arg2)
 }
 
-// DeleteCollection mocks base method.
+// DeleteCollection mocks base method
 func (m *MockPodService) DeleteCollection(arg0 context.Context, arg1 v10.ListOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteCollection", arg0, arg1)
@@ -58,23 +57,23 @@ func (m *MockPodService) DeleteCollection(arg0 context.Context, arg1 v10.ListOpt
 	return ret0
 }
 
-// DeleteCollection indicates an expected call of DeleteCollection.
+// DeleteCollection indicates an expected call of DeleteCollection
 func (mr *MockPodServiceMockRecorder) DeleteCollection(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCollection", reflect.TypeOf((*MockPodService)(nil).DeleteCollection), arg0, arg1)
 }
 
-// List mocks base method.
-func (m *MockPodService) List(arg0 context.Context) (*v1.PodList, error) {
+// List mocks base method
+func (m *MockPodService) List(arg0 context.Context, arg1 string) (*v1.PodList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", arg0)
+	ret := m.ctrl.Call(m, "List", arg0, arg1)
 	ret0, _ := ret[0].(*v1.PodList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// List indicates an expected call of List.
-func (mr *MockPodServiceMockRecorder) List(arg0 interface{}) *gomock.Call {
+// List indicates an expected call of List
+func (mr *MockPodServiceMockRecorder) List(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPodService)(nil).List), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockPodService)(nil).List), arg0, arg1)
 }

--- a/node/node.go
+++ b/node/node.go
@@ -21,8 +21,8 @@ type Service struct {
 
 // PodService represents service for manage Pods.
 type PodService interface {
-	List(ctx context.Context) (*corev1.PodList, error)
-	Delete(ctx context.Context, name string) error
+	List(ctx context.Context, namespace string) (*corev1.PodList, error)
+	Delete(ctx context.Context, name string, namespace string) error
 	DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error
 }
 
@@ -69,7 +69,7 @@ func (s *Service) Apply(ctx context.Context, nac *v1.NodeApplyConfiguration) (*c
 
 // Delete deletes the node has given name.
 func (s *Service) Delete(ctx context.Context, name string) error {
-	pl, err := s.podService.List(ctx)
+	pl, err := s.podService.List(ctx, metav1.NamespaceAll)
 	if err != nil {
 		return xerrors.Errorf("list pods: %w", err)
 	}
@@ -81,7 +81,7 @@ func (s *Service) Delete(ctx context.Context, name string) error {
 			continue
 		}
 
-		if err := s.podService.Delete(ctx, pod.Name); err != nil {
+		if err := s.podService.Delete(ctx, pod.Name, pod.Namespace); err != nil {
 			return xerrors.Errorf("delete pod: %w", err)
 		}
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	defaultNamespaceName = "default"
+	testDefaultNamespaceName1 = "default1"
 )
 
 func TestService_Delete(t *testing.T) {
@@ -35,7 +35,7 @@ func TestService_Delete(t *testing.T) {
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "pod1",
-								Namespace: defaultNamespaceName,
+								Namespace: testDefaultNamespaceName1,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "node1",
@@ -44,7 +44,7 @@ func TestService_Delete(t *testing.T) {
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "pod2",
-								Namespace: defaultNamespaceName,
+								Namespace: testDefaultNamespaceName1,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "node1",
@@ -53,7 +53,7 @@ func TestService_Delete(t *testing.T) {
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "this-pod-will-not-be-deleted",
-								Namespace: defaultNamespaceName,
+								Namespace: testDefaultNamespaceName1,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "other-node",
@@ -61,8 +61,8 @@ func TestService_Delete(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.EXPECT().Delete(gomock.Any(), "pod1", defaultNamespaceName).Return(nil)
-				m.EXPECT().Delete(gomock.Any(), "pod2", defaultNamespaceName).Return(nil)
+				m.EXPECT().Delete(gomock.Any(), "pod1", testDefaultNamespaceName1).Return(nil)
+				m.EXPECT().Delete(gomock.Any(), "pod2", testDefaultNamespaceName1).Return(nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -85,7 +85,7 @@ func TestService_Delete(t *testing.T) {
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "pod1",
-								Namespace: defaultNamespaceName,
+								Namespace: testDefaultNamespaceName1,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "node1",
@@ -94,7 +94,7 @@ func TestService_Delete(t *testing.T) {
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "pod2",
-								Namespace: defaultNamespaceName,
+								Namespace: testDefaultNamespaceName1,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "node1",
@@ -103,7 +103,7 @@ func TestService_Delete(t *testing.T) {
 						{
 							ObjectMeta: metav1.ObjectMeta{
 								Name:      "this-pod-will-not-be-deleted",
-								Namespace: defaultNamespaceName,
+								Namespace: testDefaultNamespaceName1,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "other-node",
@@ -111,8 +111,8 @@ func TestService_Delete(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.EXPECT().Delete(gomock.Any(), "pod1", defaultNamespaceName).Return(nil)
-				m.EXPECT().Delete(gomock.Any(), "pod2", defaultNamespaceName).Return(errors.New("error"))
+				m.EXPECT().Delete(gomock.Any(), "pod1", testDefaultNamespaceName1).Return(nil)
+				m.EXPECT().Delete(gomock.Any(), "pod2", testDefaultNamespaceName1).Return(errors.New("error"))
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -169,10 +169,10 @@ func TestService_DeleteCollection(t *testing.T) {
 		{
 			name: "delete all nodes and pods scheduled on them",
 			preparePodServiceMockFn: func(m *mock_node.MockPodService) {
-				m.EXPECT().DeleteCollection(gomock.Any(), metav1.ListOptions{
+				m.EXPECT().DeleteCollection(gomock.Any(), gomock.Any(), metav1.ListOptions{
 					FieldSelector: "spec.nodeName=node1",
 				}).Return(nil)
-				m.EXPECT().DeleteCollection(gomock.Any(), metav1.ListOptions{
+				m.EXPECT().DeleteCollection(gomock.Any(), gomock.Any(), metav1.ListOptions{
 					FieldSelector: "spec.nodeName=node2",
 				}).Return(nil)
 			},
@@ -198,7 +198,7 @@ func TestService_DeleteCollection(t *testing.T) {
 		{
 			name: "delete nodes with no pods",
 			preparePodServiceMockFn: func(m *mock_node.MockPodService) {
-				m.EXPECT().DeleteCollection(gomock.Any(), metav1.ListOptions{
+				m.EXPECT().DeleteCollection(gomock.Any(), gomock.Any(), metav1.ListOptions{
 					FieldSelector: "spec.nodeName=node1",
 				}).Return(nil)
 			},
@@ -219,7 +219,7 @@ func TestService_DeleteCollection(t *testing.T) {
 		{
 			name: "fail if deleteing all pods returns error",
 			preparePodServiceMockFn: func(m *mock_node.MockPodService) {
-				m.EXPECT().DeleteCollection(gomock.Any(), metav1.ListOptions{
+				m.EXPECT().DeleteCollection(gomock.Any(), gomock.Any(), metav1.ListOptions{
 					FieldSelector: "spec.nodeName=node1",
 				}).Return(errors.New("error"))
 			},

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/kubernetes-sigs/kube-scheduler-simulator/node/mock_node"
 )
 
+const (
+	defaultNamespaceName = "default"
+)
+
 func TestService_Delete(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -26,11 +30,12 @@ func TestService_Delete(t *testing.T) {
 			name:     "delete node and pods on node",
 			nodeName: "node1",
 			preparePodServiceMockFn: func(m *mock_node.MockPodService) {
-				m.EXPECT().List(gomock.Any()).Return(&corev1.PodList{
+				m.EXPECT().List(gomock.Any(), metav1.NamespaceAll).Return(&corev1.PodList{
 					Items: []corev1.Pod{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "pod1",
+								Name:      "pod1",
+								Namespace: defaultNamespaceName,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "node1",
@@ -38,7 +43,8 @@ func TestService_Delete(t *testing.T) {
 						},
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "pod2",
+								Name:      "pod2",
+								Namespace: defaultNamespaceName,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "node1",
@@ -46,7 +52,8 @@ func TestService_Delete(t *testing.T) {
 						},
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "this-pod-will-not-be-deleted",
+								Name:      "this-pod-will-not-be-deleted",
+								Namespace: defaultNamespaceName,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "other-node",
@@ -54,8 +61,8 @@ func TestService_Delete(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.EXPECT().Delete(gomock.Any(), "pod1").Return(nil)
-				m.EXPECT().Delete(gomock.Any(), "pod2").Return(nil)
+				m.EXPECT().Delete(gomock.Any(), "pod1", defaultNamespaceName).Return(nil)
+				m.EXPECT().Delete(gomock.Any(), "pod2", defaultNamespaceName).Return(nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -73,11 +80,12 @@ func TestService_Delete(t *testing.T) {
 			name:     "one of deleting pods fail",
 			nodeName: "node1",
 			preparePodServiceMockFn: func(m *mock_node.MockPodService) {
-				m.EXPECT().List(gomock.Any()).Return(&corev1.PodList{
+				m.EXPECT().List(gomock.Any(), metav1.NamespaceAll).Return(&corev1.PodList{
 					Items: []corev1.Pod{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "pod1",
+								Name:      "pod1",
+								Namespace: defaultNamespaceName,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "node1",
@@ -85,7 +93,8 @@ func TestService_Delete(t *testing.T) {
 						},
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "pod2",
+								Name:      "pod2",
+								Namespace: defaultNamespaceName,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "node1",
@@ -93,7 +102,8 @@ func TestService_Delete(t *testing.T) {
 						},
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "this-pod-will-not-be-deleted",
+								Name:      "this-pod-will-not-be-deleted",
+								Namespace: defaultNamespaceName,
 							},
 							Spec: corev1.PodSpec{
 								NodeName: "other-node",
@@ -101,8 +111,8 @@ func TestService_Delete(t *testing.T) {
 						},
 					},
 				}, nil)
-				m.EXPECT().Delete(gomock.Any(), "pod1").Return(nil)
-				m.EXPECT().Delete(gomock.Any(), "pod2").Return(errors.New("error"))
+				m.EXPECT().Delete(gomock.Any(), "pod1", defaultNamespaceName).Return(nil)
+				m.EXPECT().Delete(gomock.Any(), "pod2", defaultNamespaceName).Return(errors.New("error"))
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -114,7 +124,7 @@ func TestService_Delete(t *testing.T) {
 			name:     "delete node with no pods",
 			nodeName: "node1",
 			preparePodServiceMockFn: func(m *mock_node.MockPodService) {
-				m.EXPECT().List(gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				m.EXPECT().List(gomock.Any(), metav1.NamespaceAll).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()

--- a/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/persistentvolumeclaim/persistentvolumeclaim.go
@@ -63,9 +63,9 @@ func (s *Service) Delete(ctx context.Context, name string, namespace string) err
 	return nil
 }
 
-// DeleteCollection deletes persistentVolumeClaims according to the list options.
-func (s *Service) DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error {
-	if err := s.client.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).DeleteCollection(ctx, metav1.DeleteOptions{}, lopts); err != nil {
+// DeleteCollection deletes persistentVolumeClaims according to the list options and specified namespace.
+func (s *Service) DeleteCollection(ctx context.Context, namespace string, lopts metav1.ListOptions) error {
+	if err := s.client.CoreV1().PersistentVolumeClaims(namespace).DeleteCollection(ctx, metav1.DeleteOptions{}, lopts); err != nil {
 		return xerrors.Errorf("delete collection of persistentVolumeClaims: %w", err)
 	}
 

--- a/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/persistentvolumeclaim/persistentvolumeclaim.go
@@ -22,13 +22,9 @@ func NewPersistentVolumeClaimService(client clientset.Interface) *Service {
 	}
 }
 
-const (
-	defaultNamespaceName = "default"
-)
-
 // Get returns the persistentVolumeClaims has given name.
-func (s *Service) Get(ctx context.Context, name string) (*corev1.PersistentVolumeClaim, error) {
-	n, err := s.client.CoreV1().PersistentVolumeClaims(defaultNamespaceName).Get(ctx, name, metav1.GetOptions{})
+func (s *Service) Get(ctx context.Context, name string, namespace string) (*corev1.PersistentVolumeClaim, error) {
+	n, err := s.client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, xerrors.Errorf("get persistentVolumeClaim: %w", err)
 	}
@@ -36,8 +32,8 @@ func (s *Service) Get(ctx context.Context, name string) (*corev1.PersistentVolum
 }
 
 // List list all persistentVolumeClaims.
-func (s *Service) List(ctx context.Context) (*corev1.PersistentVolumeClaimList, error) {
-	pl, err := s.client.CoreV1().PersistentVolumeClaims(defaultNamespaceName).List(ctx, metav1.ListOptions{})
+func (s *Service) List(ctx context.Context, namespace string) (*corev1.PersistentVolumeClaimList, error) {
+	pl, err := s.client.CoreV1().PersistentVolumeClaims(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, xerrors.Errorf("list persistentVolumeClaims: %w", err)
 	}
@@ -45,11 +41,11 @@ func (s *Service) List(ctx context.Context) (*corev1.PersistentVolumeClaimList, 
 }
 
 // Apply applies the persistentVolumeClaims.
-func (s *Service) Apply(ctx context.Context, persistentVolumeClaime *v1.PersistentVolumeClaimApplyConfiguration) (*corev1.PersistentVolumeClaim, error) {
+func (s *Service) Apply(ctx context.Context, persistentVolumeClaime *v1.PersistentVolumeClaimApplyConfiguration, namespace string) (*corev1.PersistentVolumeClaim, error) {
 	persistentVolumeClaime.WithKind("PersistentVolumeClaim")
 	persistentVolumeClaime.WithAPIVersion("v1")
 
-	newpvc, err := s.client.CoreV1().PersistentVolumeClaims(defaultNamespaceName).Apply(ctx, persistentVolumeClaime, metav1.ApplyOptions{Force: true, FieldManager: "simulator"})
+	newpvc, err := s.client.CoreV1().PersistentVolumeClaims(namespace).Apply(ctx, persistentVolumeClaime, metav1.ApplyOptions{Force: true, FieldManager: "simulator"})
 	if err != nil {
 		return nil, xerrors.Errorf("apply persistentVolumeClaim: %w", err)
 	}
@@ -58,8 +54,8 @@ func (s *Service) Apply(ctx context.Context, persistentVolumeClaime *v1.Persiste
 }
 
 // Delete deletes the persistentVolumeClaims has given name.
-func (s *Service) Delete(ctx context.Context, name string) error {
-	err := s.client.CoreV1().PersistentVolumeClaims(defaultNamespaceName).Delete(ctx, name, metav1.DeleteOptions{})
+func (s *Service) Delete(ctx context.Context, name string, namespace string) error {
+	err := s.client.CoreV1().PersistentVolumeClaims(namespace).Delete(ctx, name, metav1.DeleteOptions{})
 	if err != nil {
 		return xerrors.Errorf("delete persistentVolumeClaim: %w", err)
 	}
@@ -69,7 +65,7 @@ func (s *Service) Delete(ctx context.Context, name string) error {
 
 // DeleteCollection deletes persistentVolumeClaims according to the list options.
 func (s *Service) DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error {
-	if err := s.client.CoreV1().PersistentVolumeClaims(defaultNamespaceName).DeleteCollection(ctx, metav1.DeleteOptions{}, lopts); err != nil {
+	if err := s.client.CoreV1().PersistentVolumeClaims(metav1.NamespaceAll).DeleteCollection(ctx, metav1.DeleteOptions{}, lopts); err != nil {
 		return xerrors.Errorf("delete collection of persistentVolumeClaims: %w", err)
 	}
 

--- a/persistentvolumeclaim/persistentvolumeclaim.go
+++ b/persistentvolumeclaim/persistentvolumeclaim.go
@@ -41,7 +41,7 @@ func (s *Service) List(ctx context.Context, namespace string) (*corev1.Persisten
 }
 
 // Apply applies the persistentVolumeClaims.
-func (s *Service) Apply(ctx context.Context, persistentVolumeClaime *v1.PersistentVolumeClaimApplyConfiguration, namespace string) (*corev1.PersistentVolumeClaim, error) {
+func (s *Service) Apply(ctx context.Context, namespace string, persistentVolumeClaime *v1.PersistentVolumeClaimApplyConfiguration) (*corev1.PersistentVolumeClaim, error) {
 	persistentVolumeClaime.WithKind("PersistentVolumeClaim")
 	persistentVolumeClaime.WithAPIVersion("v1")
 

--- a/persistentvolumeclaim/persistentvolumeclaim_test.go
+++ b/persistentvolumeclaim/persistentvolumeclaim_test.go
@@ -1,0 +1,248 @@
+package persistentvolumeclaim
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+const (
+	testDefaultNamespaceName1 = "default1"
+	testDefaultNamespaceName2 = "default2"
+)
+
+func TestService_Get(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                   string
+		prepareFakeClientSetFn func() *fake.Clientset
+		targetNamespace        string
+		wantPVName             string
+		wantReturn             corev1.PersistentVolumeClaim
+		wantErr                bool
+	}{
+		{
+			name: "get specifed pvc",
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				c.CoreV1().PersistentVolumeClaims(testDefaultNamespaceName1).Create(context.Background(), &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc1",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().PersistentVolumeClaims(testDefaultNamespaceName1).Create(context.Background(), &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc2",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().PersistentVolumeClaims(testDefaultNamespaceName2).Create(context.Background(), &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc3",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv1",
+					},
+				}, metav1.CreateOptions{})
+				return c
+			},
+			targetNamespace: testDefaultNamespaceName1,
+			wantPVName:      "pvc1",
+			wantErr:         false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fakeclientset := tt.prepareFakeClientSetFn()
+			s := NewPersistentVolumeClaimService(fakeclientset)
+			pod, err := s.Get(context.Background(), tt.wantPVName, tt.targetNamespace)
+
+			if (err != nil) != tt.wantErr || (pod.Name != tt.wantPVName) {
+				t.Fatalf("Get() error = %v, wantErr %v\npod name = %s, want %s", err, tt.wantErr, pod.Name, tt.wantPVName)
+			}
+		})
+	}
+}
+
+func TestService_List(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                   string
+		prepareFakeClientSetFn func() *fake.Clientset
+		targetNamespace        string
+		wantReturn             *corev1.PersistentVolumeClaimList
+		wantErr                bool
+	}{
+		{
+			name: "list pvcs spcified namespace",
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				c.CoreV1().PersistentVolumeClaims(testDefaultNamespaceName1).Create(context.Background(), &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc1",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().PersistentVolumeClaims(testDefaultNamespaceName1).Create(context.Background(), &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc2",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().PersistentVolumeClaims(testDefaultNamespaceName2).Create(context.Background(), &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc3",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv1",
+					},
+				}, metav1.CreateOptions{})
+				return c
+			},
+			targetNamespace: testDefaultNamespaceName1,
+			wantReturn: &corev1.PersistentVolumeClaimList{
+				Items: []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc1",
+							Namespace: testDefaultNamespaceName1,
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pv1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc2",
+							Namespace: testDefaultNamespaceName1,
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pv1",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "list all pvcs",
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				c.CoreV1().PersistentVolumeClaims(testDefaultNamespaceName1).Create(context.Background(), &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc1",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().PersistentVolumeClaims(testDefaultNamespaceName1).Create(context.Background(), &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc2",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().PersistentVolumeClaims(testDefaultNamespaceName2).Create(context.Background(), &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc3",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv1",
+					},
+				}, metav1.CreateOptions{})
+				return c
+			},
+			targetNamespace: corev1.NamespaceAll,
+			wantReturn: &corev1.PersistentVolumeClaimList{
+				Items: []corev1.PersistentVolumeClaim{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc1",
+							Namespace: testDefaultNamespaceName1,
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pv1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc2",
+							Namespace: testDefaultNamespaceName1,
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pv1",
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc3",
+							Namespace: testDefaultNamespaceName2,
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							VolumeName: "pv1",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "list empty if there is no pvc",
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				return c
+			},
+			targetNamespace: testDefaultNamespaceName1,
+			wantReturn:      &corev1.PersistentVolumeClaimList{},
+			wantErr:         false,
+		},
+		{
+			name: "list empty if no pvc found",
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				c.CoreV1().PersistentVolumeClaims(testDefaultNamespaceName1).Create(context.Background(), &corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pvc1",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						VolumeName: "pv1",
+					},
+				}, metav1.CreateOptions{})
+				return c
+			},
+			targetNamespace: testDefaultNamespaceName2,
+			wantReturn:      &corev1.PersistentVolumeClaimList{},
+			wantErr:         false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fakeclientset := tt.prepareFakeClientSetFn()
+			s := NewPersistentVolumeClaimService(fakeclientset)
+			pods, err := s.List(context.Background(), tt.targetNamespace)
+			diffResponse := cmp.Diff(pods, tt.wantReturn)
+			if diffResponse != "" || (err != nil) != tt.wantErr {
+				t.Fatalf("List() %v test, \nerror = %v, wantErr %v\n%s", tt.name, err, tt.wantErr, diffResponse)
+			}
+		})
+	}
+}

--- a/pod/pod.go
+++ b/pod/pod.go
@@ -42,7 +42,7 @@ func (s *Service) List(ctx context.Context, namespace string) (*corev1.PodList, 
 }
 
 // Apply applies the pod.
-func (s *Service) Apply(ctx context.Context, pod *v1.PodApplyConfiguration, namespace string) (*corev1.Pod, error) {
+func (s *Service) Apply(ctx context.Context, namespace string, pod *v1.PodApplyConfiguration) (*corev1.Pod, error) {
 	pod.WithKind("Pod")
 	pod.WithAPIVersion("v1")
 

--- a/pod/pod.go
+++ b/pod/pod.go
@@ -70,11 +70,11 @@ func (s *Service) Delete(ctx context.Context, name string, namespace string) err
 	return nil
 }
 
-// DeleteCollection deletes pods according to the list options.
-func (s *Service) DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error {
+// DeleteCollection deletes pods according to the list options and specified namespace.
+func (s *Service) DeleteCollection(ctx context.Context, namespace string, lopts metav1.ListOptions) error {
 	noGrace := int64(0)
 	s.client.CoreV1().Namespaces()
-	if err := s.client.CoreV1().Pods(metav1.NamespaceAll).DeleteCollection(ctx, metav1.DeleteOptions{
+	if err := s.client.CoreV1().Pods(namespace).DeleteCollection(ctx, metav1.DeleteOptions{
 		// need to use noGrace to avoid waiting kubelet checking.
 		// > When a force deletion is performed, the API server does not wait for confirmation from the kubelet that
 		//   the Pod has been terminated on the node it was running on.

--- a/pod/pod.go
+++ b/pod/pod.go
@@ -23,13 +23,9 @@ func NewPodService(client clientset.Interface) *Service {
 	}
 }
 
-const (
-	defaultNamespaceName = "default"
-)
-
 // Get returns the pod has given name.
-func (s *Service) Get(ctx context.Context, name string) (*corev1.Pod, error) {
-	n, err := s.client.CoreV1().Pods(defaultNamespaceName).Get(ctx, name, metav1.GetOptions{})
+func (s *Service) Get(ctx context.Context, name string, namespace string) (*corev1.Pod, error) {
+	n, err := s.client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return nil, xerrors.Errorf("get pod: %w", err)
 	}
@@ -37,8 +33,8 @@ func (s *Service) Get(ctx context.Context, name string) (*corev1.Pod, error) {
 }
 
 // List list all pods.
-func (s *Service) List(ctx context.Context) (*corev1.PodList, error) {
-	pl, err := s.client.CoreV1().Pods(defaultNamespaceName).List(ctx, metav1.ListOptions{})
+func (s *Service) List(ctx context.Context, namespace string) (*corev1.PodList, error) {
+	pl, err := s.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, xerrors.Errorf("list pods: %w", err)
 	}
@@ -46,11 +42,11 @@ func (s *Service) List(ctx context.Context) (*corev1.PodList, error) {
 }
 
 // Apply applies the pod.
-func (s *Service) Apply(ctx context.Context, pod *v1.PodApplyConfiguration) (*corev1.Pod, error) {
+func (s *Service) Apply(ctx context.Context, pod *v1.PodApplyConfiguration, namespace string) (*corev1.Pod, error) {
 	pod.WithKind("Pod")
 	pod.WithAPIVersion("v1")
 
-	newpod, err := s.client.CoreV1().Pods(defaultNamespaceName).Apply(ctx, pod, metav1.ApplyOptions{Force: true, FieldManager: "simulator"})
+	newpod, err := s.client.CoreV1().Pods(namespace).Apply(ctx, pod, metav1.ApplyOptions{Force: true, FieldManager: "simulator"})
 	if err != nil {
 		return nil, xerrors.Errorf("apply pod: %w", err)
 	}
@@ -58,9 +54,9 @@ func (s *Service) Apply(ctx context.Context, pod *v1.PodApplyConfiguration) (*co
 }
 
 // Delete deletes the pod has given name.
-func (s *Service) Delete(ctx context.Context, name string) error {
+func (s *Service) Delete(ctx context.Context, name string, namespace string) error {
 	noGrace := int64(0)
-	err := s.client.CoreV1().Pods(defaultNamespaceName).Delete(ctx, name, metav1.DeleteOptions{
+	err := s.client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{
 		// need to use noGrace to avoid waiting kubelet checking.
 		// > When a force deletion is performed, the API server does not wait for confirmation from the kubelet that
 		//   the Pod has been terminated on the node it was running on.
@@ -77,7 +73,8 @@ func (s *Service) Delete(ctx context.Context, name string) error {
 // DeleteCollection deletes pods according to the list options.
 func (s *Service) DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error {
 	noGrace := int64(0)
-	if err := s.client.CoreV1().Pods(defaultNamespaceName).DeleteCollection(ctx, metav1.DeleteOptions{
+	s.client.CoreV1().Namespaces()
+	if err := s.client.CoreV1().Pods(metav1.NamespaceAll).DeleteCollection(ctx, metav1.DeleteOptions{
 		// need to use noGrace to avoid waiting kubelet checking.
 		// > When a force deletion is performed, the API server does not wait for confirmation from the kubelet that
 		//   the Pod has been terminated on the node it was running on.

--- a/pod/pod_test.go
+++ b/pod/pod_test.go
@@ -9,6 +9,63 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+func TestService_Get(t *testing.T) {
+	t.Parallel()
+	const defaultNamespaceName = "default"
+	tests := []struct {
+		name                   string
+		prepareFakeClientSetFn func() *fake.Clientset
+		namespace              string
+		getPodName             string
+		wantPodName            string
+		wantReturn             corev1.Pod
+		wantErr                bool
+	}{
+		{
+			name: "get specifed pod",
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				c.CoreV1().Pods(defaultNamespaceName).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Pods(defaultNamespaceName).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod2",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Pods("testnamespace").Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod2",
+					},
+				}, metav1.CreateOptions{})
+				return c
+			},
+			getPodName:  "pod1",
+			namespace:   defaultNamespaceName,
+			wantPodName: "pod1",
+			wantErr:     false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fakeclientset := tt.prepareFakeClientSetFn()
+			s := NewPodService(fakeclientset)
+			pod, err := s.Get(context.Background(), tt.getPodName, tt.namespace)
+
+			if (err != nil) != tt.wantErr || (pod.Name != tt.wantPodName) {
+				t.Fatalf("Get() error = %v, wantErr %v\npod name = %s, want %s", err, tt.wantErr, pod.Name, tt.wantPodName)
+			}
+		})
+	}
+}
+
 func TestService_DeleteCollection(t *testing.T) {
 	t.Parallel()
 	const defaultNamespaceName = "default"

--- a/pod/pod_test.go
+++ b/pod/pod_test.go
@@ -260,6 +260,7 @@ func TestService_DeleteCollection(t *testing.T) {
 	tests := []struct {
 		name                   string
 		prepareFakeClientSetFn func() *fake.Clientset
+		targetNamespace        string
 		lopt                   metav1.ListOptions
 		wantErr                bool
 	}{
@@ -298,8 +299,9 @@ func TestService_DeleteCollection(t *testing.T) {
 
 				return c
 			},
-			lopt:    metav1.ListOptions{},
-			wantErr: false,
+			targetNamespace: metav1.NamespaceAll,
+			lopt:            metav1.ListOptions{},
+			wantErr:         false,
 		},
 		{
 			name: "delete all pods on node",
@@ -323,6 +325,7 @@ func TestService_DeleteCollection(t *testing.T) {
 
 				return c
 			},
+			targetNamespace: metav1.NamespaceAll,
 			lopt: metav1.ListOptions{
 				FieldSelector: "spec.nodeName!=",
 			},
@@ -335,7 +338,7 @@ func TestService_DeleteCollection(t *testing.T) {
 			t.Parallel()
 			fakeclientset := tt.prepareFakeClientSetFn()
 			s := NewPodService(fakeclientset)
-			if err := s.DeleteCollection(context.Background(), tt.lopt); (err != nil) != tt.wantErr {
+			if err := s.DeleteCollection(context.Background(), tt.targetNamespace, tt.lopt); (err != nil) != tt.wantErr {
 				t.Fatalf("DeleteCollection() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pod/pod_test.go
+++ b/pod/pod_test.go
@@ -4,19 +4,23 @@ import (
 	"context"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
+const (
+	testDefaultNamespaceName1 = "default1"
+	testDefaultNamespaceName2 = "default2"
+)
+
 func TestService_Get(t *testing.T) {
 	t.Parallel()
-	const defaultNamespaceName = "default"
 	tests := []struct {
 		name                   string
 		prepareFakeClientSetFn func() *fake.Clientset
-		namespace              string
-		getPodName             string
+		targetNamespace        string
 		wantPodName            string
 		wantReturn             corev1.Pod
 		wantErr                bool
@@ -25,7 +29,7 @@ func TestService_Get(t *testing.T) {
 			name: "get specifed pod",
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
-				c.CoreV1().Pods(defaultNamespaceName).Create(context.Background(), &corev1.Pod{
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod1",
 					},
@@ -33,22 +37,21 @@ func TestService_Get(t *testing.T) {
 						NodeName: "node1",
 					},
 				}, metav1.CreateOptions{})
-				c.CoreV1().Pods(defaultNamespaceName).Create(context.Background(), &corev1.Pod{
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod2",
 					},
 				}, metav1.CreateOptions{})
-				c.CoreV1().Pods("testnamespace").Create(context.Background(), &corev1.Pod{
+				c.CoreV1().Pods(testDefaultNamespaceName2).Create(context.Background(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod2",
 					},
 				}, metav1.CreateOptions{})
 				return c
 			},
-			getPodName:  "pod1",
-			namespace:   defaultNamespaceName,
-			wantPodName: "pod1",
-			wantErr:     false,
+			targetNamespace: testDefaultNamespaceName1,
+			wantPodName:     "pod1",
+			wantErr:         false,
 		},
 	}
 	for _, tt := range tests {
@@ -57,7 +60,7 @@ func TestService_Get(t *testing.T) {
 			t.Parallel()
 			fakeclientset := tt.prepareFakeClientSetFn()
 			s := NewPodService(fakeclientset)
-			pod, err := s.Get(context.Background(), tt.getPodName, tt.namespace)
+			pod, err := s.Get(context.Background(), tt.wantPodName, tt.targetNamespace)
 
 			if (err != nil) != tt.wantErr || (pod.Name != tt.wantPodName) {
 				t.Fatalf("Get() error = %v, wantErr %v\npod name = %s, want %s", err, tt.wantErr, pod.Name, tt.wantPodName)
@@ -66,9 +69,140 @@ func TestService_Get(t *testing.T) {
 	}
 }
 
+func TestService_List(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name                   string
+		prepareFakeClientSetFn func() *fake.Clientset
+		targetNamespace        string
+		wantReturn             *corev1.PodList
+		wantErr                bool
+	}{
+		{
+			name: "list pods spcified namespace",
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod2",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Pods(testDefaultNamespaceName2).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod3",
+					},
+				}, metav1.CreateOptions{})
+				return c
+			},
+			targetNamespace: testDefaultNamespaceName1,
+			wantReturn: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testDefaultNamespaceName1},
+						Spec:       corev1.PodSpec{NodeName: "node1"},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: testDefaultNamespaceName1},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "list all pods",
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod2",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Pods(testDefaultNamespaceName2).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod3",
+					},
+				}, metav1.CreateOptions{})
+				return c
+			},
+			targetNamespace: metav1.NamespaceAll,
+			wantReturn: &corev1.PodList{
+				Items: []corev1.Pod{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: testDefaultNamespaceName1},
+						Spec:       corev1.PodSpec{NodeName: "node1"},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: testDefaultNamespaceName1},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: testDefaultNamespaceName2},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "list empty if there is no pod",
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				return c
+			},
+			targetNamespace: metav1.NamespaceAll,
+			wantReturn:      &corev1.PodList{},
+			wantErr:         false,
+		},
+		{
+			name: "list empty if no pod found",
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+					},
+				}, metav1.CreateOptions{})
+				return c
+			},
+			targetNamespace: testDefaultNamespaceName2,
+			wantReturn:      &corev1.PodList{},
+			wantErr:         false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			fakeclientset := tt.prepareFakeClientSetFn()
+			s := NewPodService(fakeclientset)
+			pods, err := s.List(context.Background(), tt.targetNamespace)
+			diffResponse := cmp.Diff(pods, tt.wantReturn)
+			if diffResponse != "" || (err != nil) != tt.wantErr {
+				t.Fatalf("List() %v test, \nerror = %v, wantErr %v\n%s", tt.name, err, tt.wantErr, diffResponse)
+			}
+		})
+	}
+}
+
 func TestService_DeleteCollection(t *testing.T) {
 	t.Parallel()
-	const defaultNamespaceName = "default"
 	tests := []struct {
 		name                   string
 		prepareFakeClientSetFn func() *fake.Clientset
@@ -80,7 +214,7 @@ func TestService_DeleteCollection(t *testing.T) {
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
 
-				c.CoreV1().Pods(defaultNamespaceName).Create(context.Background(), &corev1.Pod{
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod1",
 					},
@@ -88,10 +222,23 @@ func TestService_DeleteCollection(t *testing.T) {
 						NodeName: "node1",
 					},
 				}, metav1.CreateOptions{})
-
-				c.CoreV1().Pods(defaultNamespaceName).Create(context.Background(), &corev1.Pod{
+				c.CoreV1().Pods(testDefaultNamespaceName2).Create(context.Background(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod2",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+					},
+				}, metav1.CreateOptions{})
+
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod3",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Pods(testDefaultNamespaceName2).Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod3",
 					},
 				}, metav1.CreateOptions{})
 
@@ -105,7 +252,7 @@ func TestService_DeleteCollection(t *testing.T) {
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
 
-				c.CoreV1().Pods(defaultNamespaceName).Create(context.Background(), &corev1.Pod{
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod1",
 					},
@@ -114,7 +261,7 @@ func TestService_DeleteCollection(t *testing.T) {
 					},
 				}, metav1.CreateOptions{})
 
-				c.CoreV1().Pods(defaultNamespaceName).Create(context.Background(), &corev1.Pod{
+				c.CoreV1().Pods(testDefaultNamespaceName1).Create(context.Background(), &corev1.Pod{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "pod2",
 					},

--- a/reset/reset.go
+++ b/reset/reset.go
@@ -13,6 +13,10 @@ type DeleteService interface {
 	DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error
 }
 
+type DeleteWithNamespaceService interface {
+	DeleteCollection(ctx context.Context, namespace string, lopts metav1.ListOptions) error
+}
+
 type SchedulerService interface {
 	ResetScheduler() error
 }
@@ -20,28 +24,44 @@ type SchedulerService interface {
 // Service cleans up resources.
 type Service struct {
 	client clientset.Interface
-	// deleteServices has the all services for each resource.
+	// deleteServices has the all services for each non-namespaced resource.
 	// key: service name.
 	deleteServices map[string]DeleteService
-	schedService   SchedulerService
+	// deleteNamespacedServices has the all services for each namespaced resource.
+	// key: service name.
+	deleteWithNamespaceService map[string]DeleteWithNamespaceService
+	schedService               SchedulerService
 }
 
 // NewResetService initializes Service.
 func NewResetService(
 	client clientset.Interface,
 	deleteServices map[string]DeleteService,
+	deleteWithNamespaceService map[string]DeleteWithNamespaceService,
 	schedService SchedulerService,
 ) *Service {
 	return &Service{
-		client:         client,
-		deleteServices: deleteServices,
-		schedService:   schedService,
+		client:                     client,
+		deleteServices:             deleteServices,
+		deleteWithNamespaceService: deleteWithNamespaceService,
+		schedService:               schedService,
 	}
 }
 
 // Reset cleans up all resources and scheduler configuration.
 func (s *Service) Reset(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
+	for k, ds := range s.deleteWithNamespaceService {
+		ds := ds
+		k := k
+		eg.Go(func() error {
+			// this method deletes all resources on all namespaces.
+			if err := ds.DeleteCollection(ctx, metav1.NamespaceAll, metav1.ListOptions{}); err != nil {
+				return xerrors.Errorf("delete collecton of %s service: %w", k, err)
+			}
+			return nil
+		})
+	}
 	for k, ds := range s.deleteServices {
 		ds := ds
 		k := k

--- a/reset/reset.go
+++ b/reset/reset.go
@@ -13,7 +13,7 @@ type DeleteService interface {
 	DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error
 }
 
-type DeleteWithNamespaceService interface {
+type DeleteServicesForNamespacedResources interface {
 	DeleteCollection(ctx context.Context, namespace string, lopts metav1.ListOptions) error
 }
 
@@ -29,29 +29,29 @@ type Service struct {
 	deleteServices map[string]DeleteService
 	// deleteNamespacedServices has the all services for each namespaced resource.
 	// key: service name.
-	deleteWithNamespaceService map[string]DeleteWithNamespaceService
-	schedService               SchedulerService
+	deleteServicesForNamespacedResources map[string]DeleteServicesForNamespacedResources
+	schedService                         SchedulerService
 }
 
 // NewResetService initializes Service.
 func NewResetService(
 	client clientset.Interface,
 	deleteServices map[string]DeleteService,
-	deleteWithNamespaceService map[string]DeleteWithNamespaceService,
+	deleteServicesForNamespacedResources map[string]DeleteServicesForNamespacedResources,
 	schedService SchedulerService,
 ) *Service {
 	return &Service{
-		client:                     client,
-		deleteServices:             deleteServices,
-		deleteWithNamespaceService: deleteWithNamespaceService,
-		schedService:               schedService,
+		client:                               client,
+		deleteServices:                       deleteServices,
+		deleteServicesForNamespacedResources: deleteServicesForNamespacedResources,
+		schedService:                         schedService,
 	}
 }
 
 // Reset cleans up all resources and scheduler configuration.
 func (s *Service) Reset(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
-	for k, ds := range s.deleteWithNamespaceService {
+	for k, ds := range s.deleteServicesForNamespacedResources {
 		ds := ds
 		k := k
 		eg.Go(func() error {

--- a/server/di/di.go
+++ b/server/di/di.go
@@ -55,7 +55,7 @@ func NewDIContainer(client clientset.Interface, restclientCfg *restclient.Config
 		"storage class":     c.storageClassService,
 		"priority class":    c.priorityClassService,
 	}
-	deleteWithNamespaceService := map[string]reset.DeleteWithNamespaceService{
+	deleteWithNamespaceService := map[string]reset.DeleteServicesForNamespacedResources{
 		"pod":                     c.podService,
 		"persistent volume claim": c.pvcService,
 	}

--- a/server/di/di.go
+++ b/server/di/di.go
@@ -55,11 +55,11 @@ func NewDIContainer(client clientset.Interface, restclientCfg *restclient.Config
 		"storage class":     c.storageClassService,
 		"priority class":    c.priorityClassService,
 	}
-	deleteWithNamespaceService := map[string]reset.DeleteServicesForNamespacedResources{
+	deleteForNamespacedResources := map[string]reset.DeleteServicesForNamespacedResources{
 		"pod":                     c.podService,
 		"persistent volume claim": c.pvcService,
 	}
-	c.resetService = reset.NewResetService(client, deleteServices, deleteWithNamespaceService, c.schedulerService)
+	c.resetService = reset.NewResetService(client, deleteServices, deleteForNamespacedResources, c.schedulerService)
 	exportService := export.NewExportService(client, c.podService, c.nodeService, c.pvService, c.pvcService, c.storageClassService, c.priorityClassService, c.schedulerService)
 	c.exportService = exportService
 	if externalImportEnabled {

--- a/server/di/di.go
+++ b/server/di/di.go
@@ -50,14 +50,16 @@ func NewDIContainer(client clientset.Interface, restclientCfg *restclient.Config
 	c.priorityClassService = priorityclass.NewPriorityClassService(client)
 
 	deleteServices := map[string]reset.DeleteService{
-		"node":                    c.nodeService,
-		"pod":                     c.podService,
-		"persistent volume":       c.pvService,
-		"persistent volume claim": c.pvcService,
-		"storage class":           c.storageClassService,
-		"priority class":          c.priorityClassService,
+		"node":              c.nodeService,
+		"persistent volume": c.pvService,
+		"storage class":     c.storageClassService,
+		"priority class":    c.priorityClassService,
 	}
-	c.resetService = reset.NewResetService(client, deleteServices, c.schedulerService)
+	deleteWithNamespaceService := map[string]reset.DeleteWithNamespaceService{
+		"pod":                     c.podService,
+		"persistent volume claim": c.pvcService,
+	}
+	c.resetService = reset.NewResetService(client, deleteServices, deleteWithNamespaceService, c.schedulerService)
 	exportService := export.NewExportService(client, c.podService, c.nodeService, c.pvService, c.pvcService, c.storageClassService, c.priorityClassService, c.schedulerService)
 	c.exportService = exportService
 	if externalImportEnabled {

--- a/server/di/interface.go
+++ b/server/di/interface.go
@@ -44,10 +44,10 @@ type PersistentVolumeService interface {
 
 // PersistentVolumeClaimService represents service for manage Nodes.
 type PersistentVolumeClaimService interface {
-	Get(ctx context.Context, name string) (*corev1.PersistentVolumeClaim, error)
-	List(ctx context.Context) (*corev1.PersistentVolumeClaimList, error)
-	Apply(ctx context.Context, pvc *configv1.PersistentVolumeClaimApplyConfiguration) (*corev1.PersistentVolumeClaim, error)
-	Delete(ctx context.Context, name string) error
+	Get(ctx context.Context, name string, namespace string) (*corev1.PersistentVolumeClaim, error)
+	List(ctx context.Context, namespace string) (*corev1.PersistentVolumeClaimList, error)
+	Apply(ctx context.Context, pvc *configv1.PersistentVolumeClaimApplyConfiguration, namespace string) (*corev1.PersistentVolumeClaim, error)
+	Delete(ctx context.Context, name string, namespace string) error
 	DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error
 }
 

--- a/server/di/interface.go
+++ b/server/di/interface.go
@@ -19,7 +19,7 @@ import (
 type PodService interface {
 	Get(ctx context.Context, name string, namespace string) (*corev1.Pod, error)
 	List(ctx context.Context, namespace string) (*corev1.PodList, error)
-	Apply(ctx context.Context, pod *configv1.PodApplyConfiguration, namespace string) (*corev1.Pod, error)
+	Apply(ctx context.Context, namespace string, pod *configv1.PodApplyConfiguration) (*corev1.Pod, error)
 	Delete(ctx context.Context, name string, namespace string) error
 	DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error
 }
@@ -46,7 +46,7 @@ type PersistentVolumeService interface {
 type PersistentVolumeClaimService interface {
 	Get(ctx context.Context, name string, namespace string) (*corev1.PersistentVolumeClaim, error)
 	List(ctx context.Context, namespace string) (*corev1.PersistentVolumeClaimList, error)
-	Apply(ctx context.Context, pvc *configv1.PersistentVolumeClaimApplyConfiguration, namespace string) (*corev1.PersistentVolumeClaim, error)
+	Apply(ctx context.Context, namespace string, pvc *configv1.PersistentVolumeClaimApplyConfiguration) (*corev1.PersistentVolumeClaim, error)
 	Delete(ctx context.Context, name string, namespace string) error
 	DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error
 }

--- a/server/di/interface.go
+++ b/server/di/interface.go
@@ -21,7 +21,7 @@ type PodService interface {
 	List(ctx context.Context, namespace string) (*corev1.PodList, error)
 	Apply(ctx context.Context, namespace string, pod *configv1.PodApplyConfiguration) (*corev1.Pod, error)
 	Delete(ctx context.Context, name string, namespace string) error
-	DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error
+	DeleteCollection(ctx context.Context, namespace string, lopts metav1.ListOptions) error
 }
 
 // NodeService represents service for manage Nodes.
@@ -48,7 +48,7 @@ type PersistentVolumeClaimService interface {
 	List(ctx context.Context, namespace string) (*corev1.PersistentVolumeClaimList, error)
 	Apply(ctx context.Context, namespace string, pvc *configv1.PersistentVolumeClaimApplyConfiguration) (*corev1.PersistentVolumeClaim, error)
 	Delete(ctx context.Context, name string, namespace string) error
-	DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error
+	DeleteCollection(ctx context.Context, namespace string, lopts metav1.ListOptions) error
 }
 
 // StorageClassService represents service for manage Pods.

--- a/server/di/interface.go
+++ b/server/di/interface.go
@@ -17,10 +17,10 @@ import (
 
 // PodService represents service for manage Pods.
 type PodService interface {
-	Get(ctx context.Context, name string) (*corev1.Pod, error)
-	List(ctx context.Context) (*corev1.PodList, error)
-	Apply(ctx context.Context, pod *configv1.PodApplyConfiguration) (*corev1.Pod, error)
-	Delete(ctx context.Context, name string) error
+	Get(ctx context.Context, name string, namespace string) (*corev1.Pod, error)
+	List(ctx context.Context, namespace string) (*corev1.PodList, error)
+	Apply(ctx context.Context, pod *configv1.PodApplyConfiguration, namespace string) (*corev1.Pod, error)
+	Delete(ctx context.Context, name string, namespace string) error
 	DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error
 }
 

--- a/server/handler/persistentvolumeclaim.go
+++ b/server/handler/persistentvolumeclaim.go
@@ -31,7 +31,7 @@ func (h *PersistentVolumeClaimHandler) ApplyPersistentVolumeClaim(c echo.Context
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 
-	newpvc, err := h.service.Apply(ctx, persistentVolumeClaim)
+	newpvc, err := h.service.Apply(ctx, persistentVolumeClaim, defaultNamespaceName)
 	if err != nil {
 		klog.Errorf("failed to apply persistentVolumeClaim: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)
@@ -46,7 +46,7 @@ func (h *PersistentVolumeClaimHandler) GetPersistentVolumeClaim(c echo.Context) 
 
 	name := c.Param("name")
 
-	p, err := h.service.Get(ctx, name)
+	p, err := h.service.Get(ctx, name, defaultNamespaceName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return echo.NewHTTPError(http.StatusNotFound)
@@ -62,7 +62,7 @@ func (h *PersistentVolumeClaimHandler) GetPersistentVolumeClaim(c echo.Context) 
 func (h *PersistentVolumeClaimHandler) ListPersistentVolumeClaim(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	ps, err := h.service.List(ctx)
+	ps, err := h.service.List(ctx, defaultNamespaceName)
 	if err != nil {
 		klog.Errorf("failed to list persistentVolumeClaims: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)
@@ -77,7 +77,7 @@ func (h *PersistentVolumeClaimHandler) DeletePersistentVolumeClaim(c echo.Contex
 
 	name := c.Param("name")
 
-	if err := h.service.Delete(ctx, name); err != nil {
+	if err := h.service.Delete(ctx, name, defaultNamespaceName); err != nil {
 		klog.Errorf("failed to delete persistentVolumeClaim: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}

--- a/server/handler/persistentvolumeclaim.go
+++ b/server/handler/persistentvolumeclaim.go
@@ -31,7 +31,7 @@ func (h *PersistentVolumeClaimHandler) ApplyPersistentVolumeClaim(c echo.Context
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 
-	newpvc, err := h.service.Apply(ctx, persistentVolumeClaim, defaultNamespaceName)
+	newpvc, err := h.service.Apply(ctx, defaultNamespaceName, persistentVolumeClaim)
 	if err != nil {
 		klog.Errorf("failed to apply persistentVolumeClaim: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)

--- a/server/handler/pod.go
+++ b/server/handler/pod.go
@@ -16,6 +16,10 @@ type PodHandler struct {
 	service di.PodService
 }
 
+const (
+	defaultNamespaceName = "default"
+)
+
 // NewPodHandler initializes PodHandler.
 func NewPodHandler(s di.PodService) *PodHandler {
 	return &PodHandler{service: s}
@@ -31,7 +35,7 @@ func (h *PodHandler) ApplyPod(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 
-	newpod, err := h.service.Apply(ctx, pod)
+	newpod, err := h.service.Apply(ctx, pod, defaultNamespaceName)
 	if err != nil {
 		klog.Errorf("failed to apply pod: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)
@@ -46,7 +50,7 @@ func (h *PodHandler) GetPod(c echo.Context) error {
 
 	name := c.Param("name")
 
-	p, err := h.service.Get(ctx, name)
+	p, err := h.service.Get(ctx, name, defaultNamespaceName)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return echo.NewHTTPError(http.StatusNotFound)
@@ -62,7 +66,7 @@ func (h *PodHandler) GetPod(c echo.Context) error {
 func (h *PodHandler) ListPod(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	ps, err := h.service.List(ctx)
+	ps, err := h.service.List(ctx, defaultNamespaceName)
 	if err != nil {
 		klog.Errorf("failed to list pods: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)
@@ -77,7 +81,7 @@ func (h *PodHandler) DeletePod(c echo.Context) error {
 
 	name := c.Param("name")
 
-	if err := h.service.Delete(ctx, name); err != nil {
+	if err := h.service.Delete(ctx, name, defaultNamespaceName); err != nil {
 		klog.Errorf("failed to delete pod: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}

--- a/server/handler/pod.go
+++ b/server/handler/pod.go
@@ -16,9 +16,9 @@ type PodHandler struct {
 	service di.PodService
 }
 
-// In PR #137, we require the specification of namespace on pod manipulation.
-// But this handler will be deprecate in the future.
-// So, this is a temporary solution.
+// Handlers support only the default namespace.
+// The previous web UI had supported only the default namespace,
+// and we deprecated all handlers to support namespaces in Web UI.
 const (
 	defaultNamespaceName = "default"
 )

--- a/server/handler/pod.go
+++ b/server/handler/pod.go
@@ -38,7 +38,7 @@ func (h *PodHandler) ApplyPod(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 
-	newpod, err := h.service.Apply(ctx, pod, defaultNamespaceName)
+	newpod, err := h.service.Apply(ctx, defaultNamespaceName, pod)
 	if err != nil {
 		klog.Errorf("failed to apply pod: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)
@@ -53,7 +53,7 @@ func (h *PodHandler) GetPod(c echo.Context) error {
 
 	name := c.Param("name")
 
-	p, err := h.service.Get(ctx, name, defaultNamespaceName)
+	p, err := h.service.Get(ctx, defaultNamespaceName, name)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return echo.NewHTTPError(http.StatusNotFound)

--- a/server/handler/pod.go
+++ b/server/handler/pod.go
@@ -16,6 +16,9 @@ type PodHandler struct {
 	service di.PodService
 }
 
+// In PR #137, we require the specification of namespace on pod manipulation.
+// But this handler will be deprecate in the future.
+// So, this is a temporary solution.
 const (
 	defaultNamespaceName = "default"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR allows us to specify namespace on manipulation of `Pod` and `PVC`.

In PR #111, we implemented the feature to import from the existing cluster. 
But it is only for the default namespace `default`.
Therefore, we support the different namespace in `import/export`.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #116

#### Special notes for your reviewer:
In PR #127 
Since in the WebUI calls the apiserver directly, in this issue, I didn't change that logic. But we must specify a namespace to support this PR's changes. So, I specified a default namespace in `Pod` and `PVC`'s handler.

/label tide/merge-method-squash
/assign @sanposhiho 