### PR TITLE
Fixed how to specify the namespace in `Reset` function for resources with a namespace

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -102,6 +102,9 @@ func (s *Service) DeleteCollection(ctx context.Context, lopts metav1.ListOptions
 	}
 	eg, ctx := errgroup.WithContext(ctx)
 	nsList, err := s.client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return xerrors.Errorf("list namespaces: %w", err)
+	}
 	for _, n := range ns.Items {
 		n := n
 		eg.Go(func() error {

--- a/node/node.go
+++ b/node/node.go
@@ -101,6 +101,7 @@ func (s *Service) DeleteCollection(ctx context.Context, lopts metav1.ListOptions
 		return xerrors.Errorf("list nodes: %w", err)
 	}
 	eg, ctx := errgroup.WithContext(ctx)
+	nsList, err := s.client.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
 	for _, n := range ns.Items {
 		n := n
 		eg.Go(func() error {
@@ -108,9 +109,12 @@ func (s *Service) DeleteCollection(ctx context.Context, lopts metav1.ListOptions
 			lopts := metav1.ListOptions{
 				FieldSelector: "spec.nodeName=" + n.Name,
 			}
-			// This method deletes all pods on all namespaces scheduled to the specified node.
-			if err := s.podService.DeleteCollection(ctx, metav1.NamespaceAll, lopts); err != nil {
-				return xerrors.Errorf("failed to delete pods on node %s: %w\n", n.Name, err)
+			for _, ns := range nsList.Items {
+				ns := ns
+				// This method deletes all pods on specified namespace scheduled to the specified node.
+				if err := s.podService.DeleteCollection(ctx, ns.GetName(), lopts); err != nil {
+					return xerrors.Errorf("failed to delete pods on node %s: %w\n", n.Name, err)
+				}
 			}
 
 			// delete specific node

--- a/node/node.go
+++ b/node/node.go
@@ -112,9 +112,8 @@ func (s *Service) DeleteCollection(ctx context.Context, lopts metav1.ListOptions
 			lopts := metav1.ListOptions{
 				FieldSelector: "spec.nodeName=" + n.Name,
 			}
+			// This method deletes all pods on specified namespace scheduled to the specified node.
 			for _, ns := range nsList.Items {
-				ns := ns
-				// This method deletes all pods on specified namespace scheduled to the specified node.
 				if err := s.podService.DeleteCollection(ctx, ns.GetName(), lopts); err != nil {
 					return xerrors.Errorf("failed to delete pods on node %s: %w\n", n.Name, err)
 				}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -260,6 +260,59 @@ func TestService_DeleteCollection(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "delete nodes with multiple existing namespaced pods",
+			preparePodServiceMockFn: func(m *mock_node.MockPodService) {
+				m.EXPECT().DeleteCollection(gomock.Any(), "default1", metav1.ListOptions{
+					FieldSelector: "spec.nodeName=node1",
+				}).Return(nil)
+				m.EXPECT().DeleteCollection(gomock.Any(), "default2", metav1.ListOptions{
+					FieldSelector: "spec.nodeName=node1",
+				}).Return(nil)
+				m.EXPECT().DeleteCollection(gomock.Any(), "default3", metav1.ListOptions{
+					FieldSelector: "spec.nodeName=node1",
+				}).Return(errors.New("error"))
+			},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				c.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default2",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Pods("default1").Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Pods("default2").Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod2",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "node1",
+					},
+				}, metav1.CreateOptions{})
+				return c
+			},
+			lopts: metav1.ListOptions{
+				FieldSelector: "spec.nodeName!=",
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -178,6 +178,11 @@ func TestService_DeleteCollection(t *testing.T) {
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
+				c.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+				}, metav1.CreateOptions{})
 				c.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node1",
@@ -204,6 +209,11 @@ func TestService_DeleteCollection(t *testing.T) {
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
+				c.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+				}, metav1.CreateOptions{})
 				c.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node1",
@@ -225,6 +235,19 @@ func TestService_DeleteCollection(t *testing.T) {
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
+				c.CoreV1().Namespaces().Create(context.Background(), &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "default",
+					},
+				}, metav1.CreateOptions{})
+				c.CoreV1().Pods("default").Create(context.Background(), &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "pod1",
+					},
+					Spec: corev1.PodSpec{
+						NodeName: "node1",
+					},
+				}, metav1.CreateOptions{})
 				c.CoreV1().Nodes().Create(context.Background(), &corev1.Node{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "node1",

--- a/reset/reset.go
+++ b/reset/reset.go
@@ -61,6 +61,7 @@ func (s *Service) Reset(ctx context.Context) error {
 		for _, ns := range nsList.Items {
 			ns := ns
 			eg.Go(func() error {
+				// this method deletes all resources on specified namespace.
 				if err := ds.DeleteCollection(ctx, ns.GetName(), metav1.ListOptions{}); err != nil {
 					return xerrors.Errorf("delete collecton of %s service: %w", k, err)
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
Fixed how to specify the namespace in `Reset` function for resources with a namespace.
The current Reset function can't work correctly.
I'm so sorry, this is caused by my fixing of #116.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Relates #84, #116

#### Special notes for your reviewer:


/label tide/merge-method-squash
