### PR TITLE
Keep priorityclasses shipped with k8s on reset

### DIFF
--- a/priorityclass/priorityclass.go
+++ b/priorityclass/priorityclass.go
@@ -61,6 +61,7 @@ func (s *Service) Delete(ctx context.Context, name string) error {
 
 // DeleteCollection deletes priorityClasses according to the list options.
 func (s *Service) DeleteCollection(ctx context.Context, lopts metav1.ListOptions) error {
+	lopts.FieldSelector = "metadata.name!=system-cluster-critical,metadata.name!=system-node-critical"
 	if err := s.client.SchedulingV1().PriorityClasses().DeleteCollection(ctx, metav1.DeleteOptions{}, lopts); err != nil {
 		return xerrors.Errorf("delete collection of priorityClasses: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Use field selector in priorityclasses deletecollection to avoid deleting system priorityclasses

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #149

#### Special notes for your reviewer:


/label tide/merge-method-squash
