### PR TITLE
support external IP in docker-compose.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ You can use the following command.
 make docker_build_and_up
 ```
 
-Then, you can access the simulator with http://localhost:3000
+Then, you can access the simulator with http://localhost:3000. If you want to deploy the simulator on a remote server and access it via a specific IP (e.g: like http://10.0.0.1:3000/), please make sure that you have executed `export SIMULATOR_EXTERNAL_IP=your.server.ip` before running `docker-compose up -d`.
 
 Note: Insufficient memory allocation may cause problems in building the image.
 Please allocate enough memory in that case.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     environment:
       - PORT=1212
       - KUBE_SCHEDULER_SIMULATOR_ETCD_URL=http://simulator-etcd:2379
-      - CORS_ALLOWED_ORIGIN_LIST=http://localhost:3000
+      - CORS_ALLOWED_ORIGIN_LIST=http://${SIMULATOR_EXTERNAL_IP:-localhost}:3000
       - KUBE_API_HOST=0.0.0.0
       - KUBE_API_PORT=3131
     ports:
@@ -22,8 +22,8 @@ services:
     container_name: simulator-frontend
     environment:
       - HOST=0.0.0.0
-      - BASE_URL=http://localhost:1212
-      - KUBE_API_SERVER_URL=http://localhost:3131
+      - BASE_URL=http://${SIMULATOR_EXTERNAL_IP:-localhost}:1212
+      - KUBE_API_SERVER_URL=http://${SIMULATOR_EXTERNAL_IP:-localhost}:3131
     ports:
     - "3000:3000"
     tty: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind documentation
/kind bug

#### What this PR does / why we need it:

This PR is aimed to fix an issue after installing `
kube-scheduler-simulator` through current docker-compose file. 

If I deploy the simulator on a remote server, it will return errors when requesting `simulator-server` due to wrong request URL, which is quite confusing.

![image](https://user-images.githubusercontent.com/3405076/184841574-651c5189-aefe-456d-b578-c1e336af3dad.png)

![image](https://user-images.githubusercontent.com/3405076/184843191-cd546a4c-8085-4fad-898e-cf1a90629b54.png)


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


/label tide/merge-method-squash
