### PR TITLE
feature(simulator): support an external scheduler

### DIFF
--- a/simulator/config/config.go
+++ b/simulator/config/config.go
@@ -17,7 +17,7 @@ import (
 )
 
 // ErrEmptyEnv represents the required environment variable don't exist.
-var ErrEmptyEnv = errors.New("env is needed, but empty")
+var ErrEmptyEnv = errors.New("env is required, but empty")
 
 // Config is configuration for simulator.
 type Config struct {
@@ -31,6 +31,8 @@ type Config struct {
 	// This field is non-empty only when ExternalImportEnabled == true.
 	ExternalKubeClientCfg *rest.Config
 	InitialSchedulerCfg   *v1beta2config.KubeSchedulerConfiguration
+	// ExternalSchedulerEnabled indicates whether an external scheduler is enabled.
+	ExternalSchedulerEnabled bool
 }
 
 // NewConfig gets some settings from environment variables.
@@ -66,14 +68,20 @@ func NewConfig() (*Config, error) {
 		return nil, xerrors.Errorf("get SchedulerCfg: %w", err)
 	}
 
+	externalSchedEnabled, err := getExternalSchedulerEnabled()
+	if err != nil {
+		return nil, xerrors.Errorf("get externalSchedulerEnabled: %w", err)
+	}
+
 	return &Config{
-		Port:                  port,
-		KubeAPIServerURL:      apiurl,
-		EtcdURL:               etcdurl,
-		CorsAllowedOriginList: corsAllowedOriginList,
-		InitialSchedulerCfg:   initialschedulerCfg,
-		ExternalImportEnabled: externalimportenabled,
-		ExternalKubeClientCfg: externalKubeClientCfg,
+		Port:                     port,
+		KubeAPIServerURL:         apiurl,
+		EtcdURL:                  etcdurl,
+		CorsAllowedOriginList:    corsAllowedOriginList,
+		InitialSchedulerCfg:      initialschedulerCfg,
+		ExternalImportEnabled:    externalimportenabled,
+		ExternalKubeClientCfg:    externalKubeClientCfg,
+		ExternalSchedulerEnabled: externalSchedEnabled,
 	}, nil
 }
 
@@ -102,6 +110,20 @@ func getKubeAPIServerURL() string {
 		h = "127.0.0.1"
 	}
 	return h + ":" + p
+}
+
+func getExternalSchedulerEnabled() (bool, error) {
+	e := os.Getenv("EXTERNAL_SCHEDULER_ENABLED")
+	if e == "" {
+		return false, nil
+	}
+
+	b, err := strconv.ParseBool(e)
+	if err != nil {
+		return false, xerrors.Errorf("EXTERNAL_SCHEDULER_ENABLED is specified, but it's not bool: %s.", e)
+	}
+
+	return b, nil
 }
 
 func getEtcdURL() (string, error) {

--- a/simulator/export/export.go
+++ b/simulator/export/export.go
@@ -10,6 +10,7 @@ package export
 
 import (
 	"context"
+	"errors"
 	"strings"
 
 	"golang.org/x/xerrors"
@@ -24,6 +25,7 @@ import (
 	"k8s.io/klog/v2"
 	v1beta2config "k8s.io/kube-scheduler/config/v1beta2"
 
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/util"
 )
 
@@ -92,7 +94,7 @@ type PriorityClassService interface {
 }
 
 type SchedulerService interface {
-	GetSchedulerConfig() *v1beta2config.KubeSchedulerConfiguration
+	GetSchedulerConfig() (*v1beta2config.KubeSchedulerConfiguration, error)
 	RestartScheduler(cfg *v1beta2config.KubeSchedulerConfiguration) error
 }
 
@@ -167,7 +169,7 @@ func (s *Service) get(ctx context.Context, opts options) (*ResourcesForExport, e
 	if err := s.listPcs(ctx, &resources, errgrp, opts); err != nil {
 		return nil, xerrors.Errorf("call listPcs: %w", err)
 	}
-	if err := s.getSchedulerConfig(&resources, errgrp); err != nil {
+	if err := s.getSchedulerConfig(&resources, errgrp, opts); err != nil {
 		return nil, xerrors.Errorf("call getSchedulerConfig: %w", err)
 	}
 
@@ -235,7 +237,10 @@ func (s *Service) Import(ctx context.Context, resources *ResourcesForImport, opt
 	}
 	if !options.ignoreSchedulerConfiguration {
 		if err := s.schedulerService.RestartScheduler(resources.SchedulerConfig); err != nil {
-			return xerrors.Errorf("restart scheduler with imported configuration: %w", err)
+			if !errors.Is(err, scheduler.ErrServiceDisabled) {
+				return xerrors.Errorf("restart scheduler with imported configuration: %w", err)
+			}
+			klog.Info("The scheduler configuration hasn't been imported because of an external scheduler is enabled.")
 		}
 	}
 	if err := s.apply(ctx, resources, options); err != nil {
@@ -358,9 +363,16 @@ func (s *Service) listPcs(ctx context.Context, r *ResourcesForExport, eg *util.S
 	return nil
 }
 
-func (s *Service) getSchedulerConfig(r *ResourcesForExport, eg *util.SemaphoredErrGroup) error {
+func (s *Service) getSchedulerConfig(r *ResourcesForExport, eg *util.SemaphoredErrGroup, opts options) error {
 	if err := eg.Go(func() error {
-		ss := s.schedulerService.GetSchedulerConfig()
+		ss, err := s.schedulerService.GetSchedulerConfig()
+		if err != nil && !errors.Is(err, scheduler.ErrServiceDisabled) {
+			if !opts.ignoreErr {
+				return xerrors.Errorf("get scheduler config: %w", err)
+			}
+			klog.Errorf("failed to get scheduler config: %v", err)
+			return nil
+		}
 		r.SchedulerConfig = ss
 		return nil
 	}); err != nil {

--- a/simulator/export/export_test.go
+++ b/simulator/export/export_test.go
@@ -3,6 +3,7 @@ package export
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -21,6 +22,7 @@ import (
 	v1beta2config "k8s.io/kube-scheduler/config/v1beta2"
 
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/export/mock_export"
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler"
 	schedulerCfg "sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/config"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/util"
 )
@@ -48,7 +50,7 @@ func TestService_Export(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -75,7 +77,7 @@ func TestService_Export(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -93,7 +95,7 @@ func TestService_Export(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -111,7 +113,7 @@ func TestService_Export(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -129,7 +131,7 @@ func TestService_Export(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -147,7 +149,7 @@ func TestService_Export(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list storageClasses"))
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -165,7 +167,7 @@ func TestService_Export(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list priorityClasses"))
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -173,6 +175,51 @@ func TestService_Export(t *testing.T) {
 			},
 			wantReturn: nil,
 			wantErr:    true,
+		},
+		{
+			name: "export failure on get scheduler config",
+			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
+				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
+				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, errors.New("hoge"))
+			},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				return c
+			},
+			wantReturn: nil,
+			wantErr:    true,
+		},
+		{
+			name: "get ErrServiceDisabled on get scheduler config, but it's ignored.",
+			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
+				pods.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PodList{Items: []corev1.Pod{}}, nil)
+				nodes.EXPECT().List(gomock.Any()).Return(&corev1.NodeList{Items: []corev1.Node{}}, nil)
+				pvs.EXPECT().List(gomock.Any()).Return(&corev1.PersistentVolumeList{Items: []corev1.PersistentVolume{}}, nil)
+				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
+				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
+				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
+				schedulers.EXPECT().GetSchedulerConfig().Return(nil, scheduler.ErrServiceDisabled)
+			},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				// add test data.
+				return c
+			},
+			wantReturn: &ResourcesForExport{
+				Pods:            []corev1.Pod{},
+				Nodes:           []corev1.Node{},
+				Pvs:             []corev1.PersistentVolume{},
+				Pvcs:            []corev1.PersistentVolumeClaim{},
+				StorageClasses:  []storagev1.StorageClass{},
+				PriorityClasses: []schedulingv1.PriorityClass{},
+				SchedulerConfig: nil,
+			},
+			wantErr: false,
 		},
 		{
 			name: "export all pods with different namespaces",
@@ -192,7 +239,7 @@ func TestService_Export(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -246,7 +293,7 @@ func TestService_Export(t *testing.T) {
 				}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -329,7 +376,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -356,7 +403,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -382,7 +429,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -408,7 +455,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -434,7 +481,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(nil, xerrors.Errorf("list PersistentVolumeClaims"))
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -460,7 +507,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list storageClasses"))
 				pcs.EXPECT().List(gomock.Any()).Return(&schedulingv1.PriorityClassList{Items: []schedulingv1.PriorityClass{}}, nil)
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -486,7 +533,7 @@ func TestService_Export_IgnoreErrOption(t *testing.T) {
 				pvcs.EXPECT().List(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaimList{Items: []corev1.PersistentVolumeClaim{}}, nil)
 				storageClasss.EXPECT().List(gomock.Any()).Return(&storagev1.StorageClassList{Items: []storagev1.StorageClass{}}, nil)
 				pcs.EXPECT().List(gomock.Any()).Return(nil, xerrors.Errorf("list priorityClasses"))
-				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{})
+				schedulers.EXPECT().GetSchedulerConfig().Return(&v1beta2config.KubeSchedulerConfiguration{}, nil)
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {
 				c := fake.NewSimpleClientset()
@@ -562,6 +609,59 @@ func TestService_Import(t *testing.T) {
 					assert.Equal(t, "PriorityClass1", *cfg.Name)
 				})
 				schedulers.EXPECT().RestartScheduler(gomock.Any()).Return(nil)
+			},
+			applyConfiguration: func() *ResourcesForImport {
+				pods := []v1.PodApplyConfiguration{}
+				nodes := []v1.NodeApplyConfiguration{}
+				pvs := []v1.PersistentVolumeApplyConfiguration{}
+				pvcs := []v1.PersistentVolumeClaimApplyConfiguration{}
+				storageclasses := []confstoragev1.StorageClassApplyConfiguration{}
+				pcs := []schedulingcfgv1.PriorityClassApplyConfiguration{}
+				pods = append(pods, *v1.Pod("Pod1", "default"))
+				nodes = append(nodes, *v1.Node("Node1"))
+				pvs = append(pvs, *v1.PersistentVolume("PV1").WithStatus(v1.PersistentVolumeStatus().WithPhase("Pending")).WithUID("test"))
+				pvcs = append(pvcs, *v1.PersistentVolumeClaim("PVC1", "default"))
+				storageclasses = append(storageclasses, *confstoragev1.StorageClass("StorageClass1"))
+				pcs = append(pcs, *schedulingcfgv1.PriorityClass("PriorityClass1"))
+				config, _ := schedulerCfg.DefaultSchedulerConfig()
+				return &ResourcesForImport{
+					Pods:            pods,
+					Nodes:           nodes,
+					Pvs:             pvs,
+					Pvcs:            pvcs,
+					StorageClasses:  storageclasses,
+					PriorityClasses: pcs,
+					SchedulerConfig: config,
+				}
+			},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				c := fake.NewSimpleClientset()
+				return c
+			},
+			wantErr: false,
+		},
+		{
+			name: "import all success (with external scheduler enabled.)",
+			prepareEachServiceMockFn: func(pods *mock_export.MockPodService, nodes *mock_export.MockNodeService, pvs *mock_export.MockPersistentVolumeService, pvcs *mock_export.MockPersistentVolumeClaimService, storageClasss *mock_export.MockStorageClassService, pcs *mock_export.MockPriorityClassService, schedulers *mock_export.MockSchedulerService) {
+				pods.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.Pod{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PodApplyConfiguration) {
+					assert.Equal(t, "Pod1", *cfg.Name)
+				})
+				nodes.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.Node{}, nil).Do(func(_ context.Context, cfg *v1.NodeApplyConfiguration) {
+					assert.Equal(t, "Node1", *cfg.Name)
+				})
+				pvs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolume{}, nil).Do(func(_ context.Context, cfg *v1.PersistentVolumeApplyConfiguration) {
+					assert.Equal(t, "PV1", *cfg.Name)
+				})
+				pvcs.EXPECT().Apply(gomock.Any(), gomock.Any(), gomock.Any()).Return(&corev1.PersistentVolumeClaim{}, nil).Do(func(_ context.Context, ns string, cfg *v1.PersistentVolumeClaimApplyConfiguration) {
+					assert.Equal(t, "PVC1", *cfg.Name)
+				})
+				storageClasss.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&storagev1.StorageClass{}, nil).Do(func(_ context.Context, cfg *confstoragev1.StorageClassApplyConfiguration) {
+					assert.Equal(t, "StorageClass1", *cfg.Name)
+				})
+				pcs.EXPECT().Apply(gomock.Any(), gomock.Any()).Return(&schedulingv1.PriorityClass{}, nil).Do(func(_ context.Context, cfg *schedulingcfgv1.PriorityClassApplyConfiguration) {
+					assert.Equal(t, "PriorityClass1", *cfg.Name)
+				})
+				schedulers.EXPECT().RestartScheduler(gomock.Any()).Return(scheduler.ErrServiceDisabled)
 			},
 			applyConfiguration: func() *ResourcesForImport {
 				pods := []v1.PodApplyConfiguration{}

--- a/simulator/export/mock_export/scheduler.go
+++ b/simulator/export/mock_export/scheduler.go
@@ -35,11 +35,12 @@ func (m *MockSchedulerService) EXPECT() *MockSchedulerServiceMockRecorder {
 }
 
 // GetSchedulerConfig mocks base method.
-func (m *MockSchedulerService) GetSchedulerConfig() *v1beta2.KubeSchedulerConfiguration {
+func (m *MockSchedulerService) GetSchedulerConfig() (*v1beta2.KubeSchedulerConfiguration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSchedulerConfig")
 	ret0, _ := ret[0].(*v1beta2.KubeSchedulerConfiguration)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetSchedulerConfig indicates an expected call of GetSchedulerConfig.

--- a/simulator/reset/reset.go
+++ b/simulator/reset/reset.go
@@ -2,11 +2,14 @@ package reset
 
 import (
 	"context"
+	"errors"
 
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clientset "k8s.io/client-go/kubernetes"
+
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler"
 )
 
 type DeleteService interface {
@@ -82,7 +85,7 @@ func (s *Service) Reset(ctx context.Context) error {
 	if err := eg.Wait(); err != nil {
 		return err
 	}
-	if err := s.schedService.ResetScheduler(); err != nil {
+	if err := s.schedService.ResetScheduler(); err != nil && !errors.Is(err, scheduler.ErrServiceDisabled) {
 		return xerrors.Errorf("reset scheduler: %w", err)
 	}
 	return nil

--- a/simulator/server/di/interface.go
+++ b/simulator/server/di/interface.go
@@ -64,7 +64,7 @@ type StorageClassService interface {
 
 // SchedulerService represents service for manage scheduler.
 type SchedulerService interface {
-	GetSchedulerConfig() *v1beta2.KubeSchedulerConfiguration
+	GetSchedulerConfig() (*v1beta2.KubeSchedulerConfiguration, error)
 	RestartScheduler(cfg *v1beta2.KubeSchedulerConfiguration) error
 	StartScheduler(cfg *v1beta2.KubeSchedulerConfiguration) error
 	ResetScheduler() error

--- a/web/components/StoreKey/SchedulerConfigurationStoreKey.ts
+++ b/web/components/StoreKey/SchedulerConfigurationStoreKey.ts
@@ -1,5 +1,5 @@
 import { InjectionKey } from "@nuxtjs/composition-api";
-import { SchedulerConfigurationStore } from "../../store/schedulerconfiguration";
+import { SchedulerConfigurationStore } from "~/store/schedulerconfiguration";
 
 const SchedulerConfigurationStoreKey: InjectionKey<SchedulerConfigurationStore> =
   Symbol("SchedulerConfigurationStore");

--- a/web/components/TopBar/SchedulerConfigurationEditButton.vue
+++ b/web/components/TopBar/SchedulerConfigurationEditButton.vue
@@ -1,11 +1,11 @@
 <template>
-  <v-btn class="ma-2" @click="onClick()">
+  <v-btn class="ma-2" @click="onClick()" v-if="!enabled()">
     <v-icon> mdi-cog </v-icon>
   </v-btn>
 </template>
 
 <script lang="ts">
-import { inject, defineComponent } from "@nuxtjs/composition-api";
+import { inject, defineComponent, onMounted } from "@nuxtjs/composition-api";
 import SchedulerConfigurationStoreKey from "../StoreKey/SchedulerConfigurationStoreKey";
 
 export default defineComponent({
@@ -15,11 +15,21 @@ export default defineComponent({
       throw new Error(`${SchedulerConfigurationStoreKey} is not provided`);
     }
 
+    const initializeSchedulerConfigurationStore = () => {
+      schedulerconfigurationstore.initialize();
+    };
+    onMounted(initializeSchedulerConfigurationStore);
+
+    const enabled = () => {
+      return schedulerconfigurationstore.disabled;
+    };
+
     const onClick = () => {
       schedulerconfigurationstore.fetchSelected();
     };
     return {
       onClick,
+      enabled,
     };
   },
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/area web
/area simulator
/kind feature

<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

support external schedulers.
When EXTERNAL_SCHEDULER_ENABLED is given as true, the simulator doesn't start a scheduler and web UI also doesn't show the gear button like this, because we cannot get and change an external scheduler's configuration.

<img width="2424" alt="スクリーンショット 2022-09-11 17 37 23" src="https://user-images.githubusercontent.com/44139130/189518854-65083b9c-1380-4ee2-ab53-24915f4c6b2d.png">

I'll create the doc for users to use an external scheduler later in another PR.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
part of #182

#### Special notes for your reviewer:


/label tide/merge-method-squash
