### PR TITLE
Fix a bug that finalscore in pod anno does not comply with weight in sche-config

### DIFF
--- a/simulator/scheduler/scheduler.go
+++ b/simulator/scheduler/scheduler.go
@@ -126,7 +126,7 @@ func (s *Service) StartScheduler(versionedcfg *v1beta2config.KubeSchedulerConfig
 	if err != nil {
 		return xerrors.Errorf("convert scheduler config to apply: %w", err)
 	}
-	registry, err := plugin.NewRegistry(s.sharedStore)
+	registry, err := plugin.NewRegistry(s.sharedStore, cfg)
 	if err != nil {
 		return xerrors.Errorf("plugin registry: %w", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/area simulator
/kind bug


#### What this PR does / why we need it:
The final score doesn't change after editing the weight of score plugins in scheduler configuration, because result store doesn't read weight from scheduler configuration.

Moreover, following the guide in [https://github.com/kubernetes-sigs/kube-scheduler-simulator/tree/master/simulator/docs/how-to-use-custom-plugins](url), if user doesn't set weight in `OutOfTreeScorePlugins()`, the final score of custom plugin will be always 0 (because weight in scheduler configuration does not take effect).

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #
I fixed this bug by the way. Should I open an issue first?

#### Special notes for your reviewer:

### Before:

![before1](https://user-images.githubusercontent.com/44139466/195333221-947c4d85-0e5b-4a67-969a-37dc5fbc61ed.png)
![before2](https://user-images.githubusercontent.com/44139466/195333321-41320a11-7edd-4fb4-a522-fc71284b61a0.png)
![before3](https://user-images.githubusercontent.com/44139466/195333337-7570e0f5-a3b7-4f51-9ce7-efef8e096926.png)

### After:

![after1](https://user-images.githubusercontent.com/44139466/195332512-ec52025a-60f1-4165-a2f7-22440d8a1809.png)
![after2](https://user-images.githubusercontent.com/44139466/195332529-c7efb96a-1687-4f9b-8fd9-45a5075a70ed.png)
![after3](https://user-images.githubusercontent.com/44139466/195332547-7a02c359-745b-4fcb-b506-1b3777a3a439.png)


/label tide/merge-method-squash
