### PR TITLE
API to fetch pod annotations and more

### DIFF
--- a/simulator/docs/api-samples/v1/pod_annotations.md
+++ b/simulator/docs/api-samples/v1/pod_annotations.md
@@ -1,0 +1,573 @@
+# Pod Annotations
+
+The simulator server provides access to unmarshalled scheduler-simulator annotations with simple GET requests producing JSON output.
+
+In addition, all pod information can be accessed as provided by apimachinery. The simulator server provides endpoints for a specific pod, all pods in a namespace, or all pods in all namespaces.
+
+## Get a specific scheduler-simulator annotation for a specific pod
+
+* For example: **"scheduler-simulator/filter-result"**
+* **Annotations are unmarshalled**
+* Data structure comes from apimachinery
+
+### curl command
+```bash
+curl http://localhost:1212/api/v1/namespaces/default/pods/pod-w64pz/metadata/annotations/scheduler-simulator/filter-result
+```
+
+### Output
+
+```json
+{
+ "node-pprb7": {
+  "AzureDiskLimits": "passed",
+  "EBSLimits": "passed",
+  "GCEPDLimits": "passed",
+  "InterPodAffinity": "passed",
+  "NodeAffinity": "passed",
+  "NodeName": "passed",
+  "NodePorts": "passed",
+  "NodeResourcesFit": "passed",
+  "NodeUnschedulable": "passed",
+  "NodeVolumeLimits": "passed",
+  "PodTopologySpread": "passed",
+  "TaintToleration": "passed",
+  "VolumeBinding": "passed",
+  "VolumeRestrictions": "passed",
+  "VolumeZone": "passed"
+ }
+}
+```
+
+## Get all scheduler-simulator annotations for a specific pod
+
+* **Annotations are unmarshalled**
+* Data structure comes from apimachinery
+* This only includes annotations that have a "scheduler-simulator/" prefix.
+
+### curl command
+```bash
+curl http://localhost:1212/api/v1/namespaces/default/pods/pod-w64pz/metadata/annotations/scheduler-simulator
+```
+
+### Output
+
+```json
+{
+ "scheduler-simulator/filter-result": {
+  "node-pprb7": {
+   "AzureDiskLimits": "passed",
+   "EBSLimits": "passed",
+   "GCEPDLimits": "passed",
+   "InterPodAffinity": "passed",
+   "NodeAffinity": "passed",
+   "NodeName": "passed",
+   "NodePorts": "passed",
+   "NodeResourcesFit": "passed",
+   "NodeUnschedulable": "passed",
+   "NodeVolumeLimits": "passed",
+   "PodTopologySpread": "passed",
+   "TaintToleration": "passed",
+   "VolumeBinding": "passed",
+   "VolumeRestrictions": "passed",
+   "VolumeZone": "passed"
+  }
+ },
+ "scheduler-simulator/finalscore-result": {},
+ "scheduler-simulator/postFilter-result": {},
+ "scheduler-simulator/score-result": {}
+}
+```
+
+## Get all annotations for a specific pod
+
+* **Annotations are not filtered or unmarshalled**
+* Data structure comes from apimachinery
+* This would include annotations that are not scoped by "scheduler-simulator" (if any were added).
+
+### curl command
+
+For example, pod **"pod-w64pz"** in **"default"** namespace:
+
+```bash
+curl http://localhost:1212/api/v1/namespaces/default/pods/pod-w64pz/metadata/annotations
+```
+
+### Output
+
+```json
+{
+ "scheduler-simulator/filter-result": "{\"node-pprb7\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"passed\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"}}",
+ "scheduler-simulator/finalscore-result": "{}",
+ "scheduler-simulator/postFilter-result": "{}",
+ "scheduler-simulator/score-result": "{}"
+}
+```
+
+## Get a specific pod
+
+* Annotations are not filtered or unmarshalled
+* Data structure comes from apimachinery
+
+### curl command
+
+For example, pod **"pod-w64pz"** in **"default"** namespace:
+
+```bash
+curl http://localhost:1212/api/v1/namespaces/default/pods/pod-w64pz
+```
+
+### Output
+
+```json
+{
+ "metadata": {
+  "name": "pod-w64pz",
+  "generateName": "pod-",
+  "namespace": "default",
+  "uid": "c5a5b6bf-2de8-4cf6-97d1-8c76ab075eb4",
+  "resourceVersion": "244",
+  "creationTimestamp": "2022-12-22T05:38:40Z",
+  "annotations": {
+   "scheduler-simulator/filter-result": "{\"node-pprb7\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"passed\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"}}",
+   "scheduler-simulator/finalscore-result": "{}",
+   "scheduler-simulator/postFilter-result": "{}",
+   "scheduler-simulator/score-result": "{}"
+  },
+  "managedFields": [
+   {
+    "manager": "simulator",
+    "operation": "Update",
+    "apiVersion": "v1",
+    "time": "2022-12-22T05:38:40Z",
+    "fieldsType": "FieldsV1",
+    "fieldsV1": {
+     "f:status": {
+      "f:conditions": {
+       ".": {},
+       "k:{\"type\":\"PodScheduled\"}": {
+        ".": {},
+        "f:lastProbeTime": {},
+        "f:lastTransitionTime": {},
+        "f:message": {},
+        "f:reason": {},
+        "f:status": {},
+        "f:type": {}
+       }
+      }
+     }
+    },
+    "subresource": "status"
+   },
+   {
+    "manager": "simulator",
+    "operation": "Update",
+    "apiVersion": "v1",
+    "time": "2022-12-22T05:38:43Z",
+    "fieldsType": "FieldsV1",
+    "fieldsV1": {
+     "f:metadata": {
+      "f:annotations": {
+       ".": {},
+       "f:scheduler-simulator/filter-result": {},
+       "f:scheduler-simulator/finalscore-result": {},
+       "f:scheduler-simulator/postFilter-result": {},
+       "f:scheduler-simulator/score-result": {}
+      },
+      "f:generateName": {}
+     },
+     "f:spec": {
+      "f:containers": {
+       "k:{\"name\":\"pause\"}": {
+        ".": {},
+        "f:image": {},
+        "f:imagePullPolicy": {},
+        "f:name": {},
+        "f:resources": {
+         ".": {},
+         "f:limits": {
+          ".": {},
+          "f:cpu": {},
+          "f:memory": {}
+         },
+         "f:requests": {
+          ".": {},
+          "f:cpu": {},
+          "f:memory": {}
+         }
+        },
+        "f:terminationMessagePath": {},
+        "f:terminationMessagePolicy": {}
+       }
+      },
+      "f:dnsPolicy": {},
+      "f:enableServiceLinks": {},
+      "f:restartPolicy": {},
+      "f:schedulerName": {},
+      "f:securityContext": {},
+      "f:terminationGracePeriodSeconds": {}
+     }
+    }
+   }
+  ]
+ },
+ "spec": {
+  "containers": [
+   {
+    "name": "pause",
+    "image": "k8s.gcr.io/pause:3.5",
+    "resources": {
+     "limits": {
+      "cpu": "100m",
+      "memory": "16Gi"
+     },
+     "requests": {
+      "cpu": "100m",
+      "memory": "16Gi"
+     }
+    },
+    "terminationMessagePath": "/dev/termination-log",
+    "terminationMessagePolicy": "File",
+    "imagePullPolicy": "IfNotPresent"
+   }
+  ],
+  "restartPolicy": "Always",
+  "terminationGracePeriodSeconds": 30,
+  "dnsPolicy": "ClusterFirst",
+  "nodeName": "node-pprb7",
+  "securityContext": {},
+  "schedulerName": "default-scheduler",
+  "priority": 0,
+  "enableServiceLinks": true,
+  "preemptionPolicy": "PreemptLowerPriority"
+ },
+ "status": {
+  "phase": "Pending",
+  "conditions": [
+   {
+    "type": "PodScheduled",
+    "status": "True",
+    "lastProbeTime": null,
+    "lastTransitionTime": "2022-12-22T05:38:43Z"
+   }
+  ],
+  "qosClass": "Guaranteed"
+ }
+}
+```
+
+## Get all pods for a specific namespace
+
+* Annotations are not filtered or unmarshalled
+* Data structure comes from apimachinery
+
+### curl command
+
+For example, **"default"** namespace:
+
+```bash
+curl http://localhost:1212/api/v1/namespaces/default/pods
+```
+
+### Output
+
+```json
+{
+ "metadata": {
+  "resourceVersion": "359"
+ },
+ "items": [
+  {
+   "metadata": {
+    "name": "pod-w64pz",
+    "generateName": "pod-",
+    "namespace": "default",
+    "uid": "c5a5b6bf-2de8-4cf6-97d1-8c76ab075eb4",
+    "resourceVersion": "244",
+    "creationTimestamp": "2022-12-22T05:38:40Z",
+    "annotations": {
+     "scheduler-simulator/filter-result": "{\"node-pprb7\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"passed\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"}}",
+     "scheduler-simulator/finalscore-result": "{}",
+     "scheduler-simulator/postFilter-result": "{}",
+     "scheduler-simulator/score-result": "{}"
+    },
+    "managedFields": [
+     {
+      "manager": "simulator",
+      "operation": "Update",
+      "apiVersion": "v1",
+      "time": "2022-12-22T05:38:40Z",
+      "fieldsType": "FieldsV1",
+      "fieldsV1": {
+       "f:status": {
+        "f:conditions": {
+         ".": {},
+         "k:{\"type\":\"PodScheduled\"}": {
+          ".": {},
+          "f:lastProbeTime": {},
+          "f:lastTransitionTime": {},
+          "f:message": {},
+          "f:reason": {},
+          "f:status": {},
+          "f:type": {}
+         }
+        }
+       }
+      },
+      "subresource": "status"
+     },
+     {
+      "manager": "simulator",
+      "operation": "Update",
+      "apiVersion": "v1",
+      "time": "2022-12-22T05:38:43Z",
+      "fieldsType": "FieldsV1",
+      "fieldsV1": {
+       "f:metadata": {
+        "f:annotations": {
+         ".": {},
+         "f:scheduler-simulator/filter-result": {},
+         "f:scheduler-simulator/finalscore-result": {},
+         "f:scheduler-simulator/postFilter-result": {},
+         "f:scheduler-simulator/score-result": {}
+        },
+        "f:generateName": {}
+       },
+       "f:spec": {
+        "f:containers": {
+         "k:{\"name\":\"pause\"}": {
+          ".": {},
+          "f:image": {},
+          "f:imagePullPolicy": {},
+          "f:name": {},
+          "f:resources": {
+           ".": {},
+           "f:limits": {
+            ".": {},
+            "f:cpu": {},
+            "f:memory": {}
+           },
+           "f:requests": {
+            ".": {},
+            "f:cpu": {},
+            "f:memory": {}
+           }
+          },
+          "f:terminationMessagePath": {},
+          "f:terminationMessagePolicy": {}
+         }
+        },
+        "f:dnsPolicy": {},
+        "f:enableServiceLinks": {},
+        "f:restartPolicy": {},
+        "f:schedulerName": {},
+        "f:securityContext": {},
+        "f:terminationGracePeriodSeconds": {}
+       }
+      }
+     }
+    ]
+   },
+   "spec": {
+    "containers": [
+     {
+      "name": "pause",
+      "image": "k8s.gcr.io/pause:3.5",
+      "resources": {
+       "limits": {
+        "cpu": "100m",
+        "memory": "16Gi"
+       },
+       "requests": {
+        "cpu": "100m",
+        "memory": "16Gi"
+       }
+      },
+      "terminationMessagePath": "/dev/termination-log",
+      "terminationMessagePolicy": "File",
+      "imagePullPolicy": "IfNotPresent"
+     }
+    ],
+    "restartPolicy": "Always",
+    "terminationGracePeriodSeconds": 30,
+    "dnsPolicy": "ClusterFirst",
+    "nodeName": "node-pprb7",
+    "securityContext": {},
+    "schedulerName": "default-scheduler",
+    "priority": 0,
+    "enableServiceLinks": true,
+    "preemptionPolicy": "PreemptLowerPriority"
+   },
+   "status": {
+    "phase": "Pending",
+    "conditions": [
+     {
+      "type": "PodScheduled",
+      "status": "True",
+      "lastProbeTime": null,
+      "lastTransitionTime": "2022-12-22T05:38:43Z"
+     }
+    ],
+    "qosClass": "Guaranteed"
+   }
+  }
+ ]
+}
+```
+
+## Get all pods
+
+* All pods across all namespaces.
+* Annotations are not filtered or unmarshalled
+* Data structure comes from apimachinery
+
+### curl command
+```bash
+curl http://localhost:1212/api/v1/pods
+```
+
+### Output
+
+```json
+{
+ "metadata": {
+  "resourceVersion": "258"
+ },
+ "items": [
+  {
+   "metadata": {
+    "name": "pod-w64pz",
+    "generateName": "pod-",
+    "namespace": "default",
+    "uid": "c5a5b6bf-2de8-4cf6-97d1-8c76ab075eb4",
+    "resourceVersion": "244",
+    "creationTimestamp": "2022-12-22T05:38:40Z",
+    "annotations": {
+     "scheduler-simulator/filter-result": "{\"node-pprb7\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"passed\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"}}",
+     "scheduler-simulator/finalscore-result": "{}",
+     "scheduler-simulator/postFilter-result": "{}",
+     "scheduler-simulator/score-result": "{}"
+    },
+    "managedFields": [
+     {
+      "manager": "simulator",
+      "operation": "Update",
+      "apiVersion": "v1",
+      "time": "2022-12-22T05:38:40Z",
+      "fieldsType": "FieldsV1",
+      "fieldsV1": {
+       "f:status": {
+        "f:conditions": {
+         ".": {},
+         "k:{\"type\":\"PodScheduled\"}": {
+          ".": {},
+          "f:lastProbeTime": {},
+          "f:lastTransitionTime": {},
+          "f:message": {},
+          "f:reason": {},
+          "f:status": {},
+          "f:type": {}
+         }
+        }
+       }
+      },
+      "subresource": "status"
+     },
+     {
+      "manager": "simulator",
+      "operation": "Update",
+      "apiVersion": "v1",
+      "time": "2022-12-22T05:38:43Z",
+      "fieldsType": "FieldsV1",
+      "fieldsV1": {
+       "f:metadata": {
+        "f:annotations": {
+         ".": {},
+         "f:scheduler-simulator/filter-result": {},
+         "f:scheduler-simulator/finalscore-result": {},
+         "f:scheduler-simulator/postFilter-result": {},
+         "f:scheduler-simulator/score-result": {}
+        },
+        "f:generateName": {}
+       },
+       "f:spec": {
+        "f:containers": {
+         "k:{\"name\":\"pause\"}": {
+          ".": {},
+          "f:image": {},
+          "f:imagePullPolicy": {},
+          "f:name": {},
+          "f:resources": {
+           ".": {},
+           "f:limits": {
+            ".": {},
+            "f:cpu": {},
+            "f:memory": {}
+           },
+           "f:requests": {
+            ".": {},
+            "f:cpu": {},
+            "f:memory": {}
+           }
+          },
+          "f:terminationMessagePath": {},
+          "f:terminationMessagePolicy": {}
+         }
+        },
+        "f:dnsPolicy": {},
+        "f:enableServiceLinks": {},
+        "f:restartPolicy": {},
+        "f:schedulerName": {},
+        "f:securityContext": {},
+        "f:terminationGracePeriodSeconds": {}
+       }
+      }
+     }
+    ]
+   },
+   "spec": {
+    "containers": [
+     {
+      "name": "pause",
+      "image": "k8s.gcr.io/pause:3.5",
+      "resources": {
+       "limits": {
+        "cpu": "100m",
+        "memory": "16Gi"
+       },
+       "requests": {
+        "cpu": "100m",
+        "memory": "16Gi"
+       }
+      },
+      "terminationMessagePath": "/dev/termination-log",
+      "terminationMessagePolicy": "File",
+      "imagePullPolicy": "IfNotPresent"
+     }
+    ],
+    "restartPolicy": "Always",
+    "terminationGracePeriodSeconds": 30,
+    "dnsPolicy": "ClusterFirst",
+    "nodeName": "node-pprb7",
+    "securityContext": {},
+    "schedulerName": "default-scheduler",
+    "priority": 0,
+    "enableServiceLinks": true,
+    "preemptionPolicy": "PreemptLowerPriority"
+   },
+   "status": {
+    "phase": "Pending",
+    "conditions": [
+     {
+      "type": "PodScheduled",
+      "status": "True",
+      "lastProbeTime": null,
+      "lastTransitionTime": "2022-12-22T05:38:43Z"
+     }
+    ],
+    "qosClass": "Guaranteed"
+   }
+  }
+ ]
+}
+```

--- a/simulator/server/handler/pod.go
+++ b/simulator/server/handler/pod.go
@@ -1,0 +1,104 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"k8s.io/klog/v2"
+
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/server/di"
+)
+
+const indent = " "
+
+// PodHandler is handler for pod service
+type PodHandler struct {
+	service di.PodService
+}
+
+func NewPodHandler(s di.PodService) *PodHandler {
+	return &PodHandler{
+		service: s,
+	}
+}
+
+// GetPods lists all pods in all namespaces
+func (h *PodHandler) GetPods(c echo.Context) error {
+	ctx := c.Request().Context()
+	pods, err := h.service.List(ctx, "")
+	if err != nil {
+		klog.Errorf("failed to get list of pods: %+v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
+	}
+
+	return c.JSONPretty(http.StatusOK, pods, indent)
+}
+
+// GetPod gets a pod using namespace and name params
+func (h *PodHandler) GetPod(c echo.Context) error {
+	ctx := c.Request().Context()
+	name := c.Param("name")
+	namespace := c.Param("namespace")
+	pod, err := h.service.Get(ctx, name, namespace)
+	if err != nil {
+		klog.Errorf("failed to get pod %v:%v: %+v", namespace, name, err)
+		return echo.NewHTTPError(http.StatusNotFound)
+	}
+
+	return c.JSONPretty(http.StatusOK, pod, indent)
+}
+
+// GetPodMetaDataAnnotations gets a pod annotations using namespace, name params and annotation params
+func (h *PodHandler) GetPodMetaDataAnnotations(c echo.Context) error {
+	ctx := c.Request().Context()
+	name := c.Param("name")
+	namespace := c.Param("namespace")
+	annotation := c.Param("annotation")
+	pod, err := h.service.Get(ctx, name, namespace)
+	if err != nil {
+		klog.Errorf("failed to get pod annotations: %+v", err)
+		return echo.NewHTTPError(http.StatusNotFound)
+	}
+
+	var ret interface{}
+
+	switch annotation {
+	case "":
+		// Dump all annotations (don't unmarshall because who knows what could be in there)
+		ret = pod.Annotations
+	case "scheduler-simulator", "scheduler-simulator/":
+		// Get and unmarshal all the scheduler-simulator annotations (prefix is "scheduler-simulator/")
+		annotations := make(map[string]map[string]map[string]string)
+		ret = annotations
+		for k, v := range pod.Annotations {
+			if strings.HasPrefix(k, "scheduler-simulator") {
+				nodeAnnotations := make(map[string]map[string]string)
+				err := json.Unmarshal([]byte(v), &nodeAnnotations)
+				if err != nil {
+					klog.Errorf("failed to unmarshal a scheduler-simulator annotation: %+v", err)
+					return echo.NewHTTPError(http.StatusInternalServerError)
+				}
+				annotations[k] = nodeAnnotations
+			}
+		}
+	default:
+		a, ok := pod.Annotations[annotation]
+		if !ok {
+			klog.Errorf("annotation %v not found on %v/%v", annotation, namespace, name)
+			return echo.NewHTTPError(http.StatusNotFound)
+		} else {
+			nodeAnnotations := make(map[string]map[string]string)
+			err := json.Unmarshal([]byte(a), &nodeAnnotations)
+			if err != nil {
+				klog.Errorf("failed to unmarshal annotation %v returning unmarshalled: %+v", annotation, err)
+				ret = a
+			} else {
+				ret = nodeAnnotations
+			}
+		}
+	}
+
+	return c.JSONPretty(http.StatusOK, ret, indent)
+}

--- a/simulator/server/handler/pod.go
+++ b/simulator/server/handler/pod.go
@@ -13,7 +13,7 @@ import (
 
 const indent = " "
 
-// PodHandler is handler for pod service
+// PodHandler is handler for pod service.
 type PodHandler struct {
 	service di.PodService
 }
@@ -24,7 +24,7 @@ func NewPodHandler(s di.PodService) *PodHandler {
 	}
 }
 
-// GetPods lists all pods in all namespaces
+// GetPods lists all pods in all namespaces.
 func (h *PodHandler) GetPods(c echo.Context) error {
 	ctx := c.Request().Context()
 	pods, err := h.service.List(ctx, "")
@@ -36,7 +36,7 @@ func (h *PodHandler) GetPods(c echo.Context) error {
 	return c.JSONPretty(http.StatusOK, pods, indent)
 }
 
-// GetPod gets a pod using namespace and name params
+// GetPod gets a pod using namespace and name params.
 func (h *PodHandler) GetPod(c echo.Context) error {
 	ctx := c.Request().Context()
 	name := c.Param("name")
@@ -50,7 +50,7 @@ func (h *PodHandler) GetPod(c echo.Context) error {
 	return c.JSONPretty(http.StatusOK, pod, indent)
 }
 
-// GetPodMetaDataAnnotations gets a pod annotations using namespace, name params and annotation params
+// GetPodMetaDataAnnotations gets a pod annotations using namespace, name params and annotation params.
 func (h *PodHandler) GetPodMetaDataAnnotations(c echo.Context) error {
 	ctx := c.Request().Context()
 	name := c.Param("name")
@@ -88,15 +88,14 @@ func (h *PodHandler) GetPodMetaDataAnnotations(c echo.Context) error {
 		if !ok {
 			klog.Errorf("annotation %v not found on %v/%v", annotation, namespace, name)
 			return echo.NewHTTPError(http.StatusNotFound)
+		}
+		nodeAnnotations := make(map[string]map[string]string)
+		err := json.Unmarshal([]byte(a), &nodeAnnotations)
+		if err != nil {
+			klog.Errorf("failed to unmarshal annotation %v returning unmarshalled: %+v", annotation, err)
+			ret = a
 		} else {
-			nodeAnnotations := make(map[string]map[string]string)
-			err := json.Unmarshal([]byte(a), &nodeAnnotations)
-			if err != nil {
-				klog.Errorf("failed to unmarshal annotation %v returning unmarshalled: %+v", annotation, err)
-				ret = a
-			} else {
-				ret = nodeAnnotations
-			}
+			ret = nodeAnnotations
 		}
 	}
 

--- a/simulator/server/handler/pod_test.go
+++ b/simulator/server/handler/pod_test.go
@@ -1,0 +1,361 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/labstack/echo/v4"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"k8s.io/client-go/kubernetes/fake"
+
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/pod"
+)
+
+const (
+	namespace1      = "namespace1"
+	namespace2      = "namespace2"
+	node1           = "node1"
+	pod1            = "pod1"
+	pod2            = "pod2"
+	bogusPod        = "boguspod"
+	bogusNS         = "bogusns"
+	bogusAnnotation = "bogusannotation"
+)
+
+type test struct {
+	name                   string
+	params                 map[string]string
+	prepareFakeClientSetFn func() *fake.Clientset
+	wantCode               int
+	wantBody               string
+	wantErr                bool
+}
+
+func TestPodHandler_GetPods(t *testing.T) {
+
+	tests := []test{
+		{
+			name:   "no pods",
+			params: map[string]string{},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return fake.NewSimpleClientset()
+			},
+			wantCode: http.StatusOK,
+			wantErr:  false,
+		},
+		{
+			name:   "all pods",
+			params: map[string]string{},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return prepareFakeClientset()
+			},
+			wantCode: http.StatusOK,
+			wantErr:  false,
+			wantBody: `{ 
+                "metadata": {},
+                "items": [
+                {
+          		    "metadata": {
+				 		"annotations": {
+				            "not-our-usual-annotation":          "some annotation shows up here",
+				            "scheduler-simulator/filter-result": "{\"node-45pvw\": {\"AzureDiskLimits\": \"passed\", \"EBSLimits\": \"passed\"}}",
+				            "scheduler-simulator/future-thing": "{\"node-45pvw\": {\"SomethingElse\": \"passed\", \"AnotherThing\": \"passed\"}}",
+				            "scheduler-simulator/score-result": "{}"
+		                },
+                        "creationTimestamp": null,
+                        "name":              "pod1",
+                        "namespace":         "namespace1"
+                    },
+                    "spec":   {"containers": null, "nodeName": "node1"},
+                    "status": {}
+         		},
+          		{
+          			"metadata": {
+          				"creationTimestamp": null,
+          				"name":              "pod2",
+          				"namespace":         "namespace2"
+          			},
+                    "spec":   { "containers": null },
+          			"status": {}
+         		}]
+            }`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := tt.prepareFakeClientSetFn()
+			rec, recordingContext := prepareRecordingContext(tt)
+
+			err := NewPodHandler(pod.NewPodService(client)).GetPods(recordingContext)
+			checkResults(t, tt, err, rec)
+		})
+	}
+}
+
+func TestPodHandler_GetPod(t *testing.T) {
+
+	tests := []test{
+		{
+			name:   "namespace not found",
+			params: map[string]string{"namespace": bogusNS, "name": pod1},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return fake.NewSimpleClientset()
+			},
+			wantCode: http.StatusNotFound,
+			wantErr:  true,
+		},
+		{
+			name:   "pod not found",
+			params: map[string]string{"namespace": namespace1, "name": bogusPod},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return fake.NewSimpleClientset()
+			},
+			wantCode: http.StatusNotFound,
+			wantErr:  true,
+		},
+		{
+			name:   "pod found",
+			params: map[string]string{"namespace": namespace2, "name": pod2},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return prepareFakeClientset()
+			},
+			wantCode: http.StatusOK,
+			wantErr:  false,
+			wantBody: `{ 
+			 	"metadata": {
+				 		"creationTimestamp": null,
+				 		"name":              "pod2",
+				 		"namespace":         "namespace2"
+		        },
+			 	"spec": { "containers": null },
+			 	"status": {}
+            }`,
+		},
+		{
+			name:   "pod found on node",
+			params: map[string]string{"namespace": namespace1, "name": pod1},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return prepareFakeClientset()
+			},
+			wantCode: http.StatusOK,
+			wantErr:  false,
+			wantBody: `{ 
+			 	"metadata": {
+				 		"annotations": {
+				            "not-our-usual-annotation":          "some annotation shows up here",
+				            "scheduler-simulator/filter-result": "{\"node-45pvw\": {\"AzureDiskLimits\": \"passed\", \"EBSLimits\": \"passed\"}}",
+				            "scheduler-simulator/future-thing": "{\"node-45pvw\": {\"SomethingElse\": \"passed\", \"AnotherThing\": \"passed\"}}",
+				            "scheduler-simulator/score-result": "{}"
+		                },
+				 		"creationTimestamp": null,
+				 		"name":              "pod1",
+				 		"namespace":         "namespace1"
+		        },
+			 	"spec": { "containers": null, "nodeName": "node1" },
+			 	"status": {}
+            }`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := tt.prepareFakeClientSetFn()
+			rec, recordingContext := prepareRecordingContext(tt)
+
+			err := NewPodHandler(pod.NewPodService(client)).GetPod(recordingContext)
+			checkResults(t, tt, err, rec)
+		})
+	}
+}
+
+func TestPodHandler_GetPodMetadataAnnotations(t *testing.T) {
+
+	tests := []test{
+		{
+			name:   "no pods",
+			params: map[string]string{"namespace": bogusNS, "name": bogusPod, "annotation": bogusAnnotation},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return fake.NewSimpleClientset()
+			},
+			wantCode: http.StatusNotFound,
+			wantErr:  true,
+		},
+		{
+			name:   "pod found but not annotation",
+			params: map[string]string{"namespace": namespace1, "name": pod1, "annotation": bogusAnnotation},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return prepareFakeClientset()
+			},
+			wantCode: http.StatusNotFound,
+			wantErr:  true,
+		},
+		{
+			name:   "pod found on node with specific annotation",
+			params: map[string]string{"namespace": namespace1, "name": pod1, "annotation": "scheduler-simulator/filter-result"},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return prepareFakeClientset()
+			},
+			wantCode: http.StatusOK,
+			wantErr:  false,
+			wantBody: `{ 
+                "node-45pvw": {
+                    "AzureDiskLimits": "passed",
+                    "EBSLimits": "passed"
+		        }
+            }`,
+		},
+		{
+			name:   "pod found on node with scheduler-simulator annotations",
+			params: map[string]string{"namespace": namespace1, "name": pod1, "annotation": "scheduler-simulator"},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return prepareFakeClientset()
+			},
+			wantCode: http.StatusOK,
+			wantErr:  false,
+			wantBody: `{ 
+        	    "scheduler-simulator/filter-result": {
+        		    "node-45pvw": {
+                        "AzureDiskLimits": "passed",
+                        "EBSLimits": "passed"
+                    }
+        	    },
+        	    "scheduler-simulator/future-thing": {
+        		    "node-45pvw": {
+                        "AnotherThing": "passed",
+                        "SomethingElse": "passed"
+                    }
+        	    },
+        	    "scheduler-simulator/score-result": {}
+            }`,
+		},
+		{
+			name:   "pod found on node with some random annotation",
+			params: map[string]string{"namespace": namespace1, "name": pod1, "annotation": "not-our-usual-annotation"},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return prepareFakeClientset()
+			},
+			wantCode: http.StatusOK,
+			wantErr:  false,
+			wantBody: "some annotation shows up here",
+		},
+		{
+			name:   "pod found on node, dumping all annotations",
+			params: map[string]string{"namespace": namespace1, "name": pod1, "annotation": ""},
+			prepareFakeClientSetFn: func() *fake.Clientset {
+				return prepareFakeClientset()
+			},
+			wantCode: http.StatusOK,
+			wantErr:  false,
+			wantBody: `{
+				"not-our-usual-annotation":          "some annotation shows up here",
+				"scheduler-simulator/filter-result": "{\"node-45pvw\": {\"AzureDiskLimits\": \"passed\", \"EBSLimits\": \"passed\"}}",
+				"scheduler-simulator/future-thing": "{\"node-45pvw\": {\"SomethingElse\": \"passed\", \"AnotherThing\": \"passed\"}}",
+				"scheduler-simulator/score-result": "{}"
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			client := tt.prepareFakeClientSetFn()
+			rec, recordingContext := prepareRecordingContext(tt)
+
+			err := NewPodHandler(pod.NewPodService(client)).GetPodMetaDataAnnotations(recordingContext)
+			checkResults(t, tt, err, rec)
+		})
+	}
+}
+
+// checkResults logs and fails if the expected err, code, and body are not returned/recorded
+func checkResults(t *testing.T, tt test, err error, rec *httptest.ResponseRecorder) {
+	t.Helper()
+	if (err != nil) != tt.wantErr {
+		t.Fatalf("%v test: error=%v, wantErr=%v", tt.name, err, tt.wantErr)
+	}
+
+	// HTTP status code is either recorded or it is in the error
+	code := rec.Code
+	if err != nil {
+		httpError := err.(*echo.HTTPError)
+		code = httpError.Code
+	}
+	if code != tt.wantCode {
+		t.Fatalf("%v test: mismatch code=%v, wantCode=%v", tt.name, code, tt.wantCode)
+	}
+
+	// Compare recorded body to wantBody (not testing error message)
+	if err == nil && tt.wantBody != "" {
+		var want, got interface{}
+		if err := json.Unmarshal([]byte(tt.wantBody), &want); err != nil {
+			// can test for things we cannot unmarshal
+			want = tt.wantBody
+		}
+		if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+			// can test for things we cannot unmarshal
+			got = rec.Body
+		}
+		diffResponse := cmp.Diff(want, got)
+		if diffResponse != "" {
+			t.Fatalf("%v test: body mismatch (-want +got):\n%v", tt.name, diffResponse)
+		}
+	}
+}
+
+func prepareRecordingContext(tt struct {
+	name                   string
+	params                 map[string]string
+	prepareFakeClientSetFn func() *fake.Clientset
+	wantCode               int
+	wantBody               string
+	wantErr                bool
+}) (*httptest.ResponseRecorder, echo.Context) {
+	req := httptest.NewRequest(http.MethodGet, "/dummy", nil) // Just enough for context and handler
+	rec := httptest.NewRecorder()
+	recordingContext := echo.New().NewContext(req, rec)
+	n := len(tt.params)
+	if n > 0 {
+		names := make([]string, 0, n)
+		values := make([]string, 0, n)
+		for k, v := range tt.params {
+			names = append(names, k)
+			values = append(values, v)
+		}
+		recordingContext.SetParamNames(names...)
+		recordingContext.SetParamValues(values...)
+	}
+	return rec, recordingContext
+}
+
+func prepareFakeClientset() *fake.Clientset {
+	c := fake.NewSimpleClientset()
+	c.CoreV1().Pods(namespace1).Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pod1,
+			Annotations: map[string]string{
+				"scheduler-simulator/filter-result": `{"node-45pvw": {"AzureDiskLimits": "passed", "EBSLimits": "passed"}}`,
+				"scheduler-simulator/score-result":  `{}`,
+				"scheduler-simulator/future-thing":  `{"node-45pvw": {"SomethingElse": "passed", "AnotherThing": "passed"}}`,
+				"not-our-usual-annotation":          "some annotation shows up here",
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: node1,
+		},
+	}, metav1.CreateOptions{})
+	c.CoreV1().Pods(namespace2).Create(context.Background(), &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: pod2,
+		},
+	}, metav1.CreateOptions{})
+	return c
+}

--- a/simulator/server/server.go
+++ b/simulator/server/server.go
@@ -36,6 +36,7 @@ func NewSimulatorServer(cfg *config.Config, dic *di.Container) *SimulatorServer 
 	exportHandler := handler.NewExportHandler(dic.ExportService())
 	resetHandler := handler.NewResetHandler(dic.ResetService())
 	resourcewatcherHandler := handler.NewResourceWatcherHandler(dic.ResourceWatcherService())
+	podHandler := handler.NewPodHandler(dic.PodService())
 
 	// register apis
 	v1 := e.Group("/api/v1")
@@ -49,6 +50,12 @@ func NewSimulatorServer(cfg *config.Config, dic *di.Container) *SimulatorServer 
 	v1.POST("/import", exportHandler.Import)
 
 	v1.GET("/listwatchresources", resourcewatcherHandler.ListWatchResources)
+
+	v1.GET("/pods", podHandler.GetPods)
+	v1.GET("/namespaces/:namespace/pods/:name/metadata/annotations/:annotation", podHandler.GetPodMetaDataAnnotations)
+	v1.GET("/namespaces/:namespace/pods/:name/metadata/annotations", podHandler.GetPodMetaDataAnnotations)
+	v1.GET("/namespaces/:namespace/pods/:name", podHandler.GetPod)
+	v1.GET("/namespaces/:namespace/pods", podHandler.GetPods)
 
 	// initialize SimulatorServer.
 	s := &SimulatorServer{e: e}


### PR DESCRIPTION
Closes: 109

Adding endpoint /namespaces/:namespace/pods/:name/metadata/annotations/:annotation

This allows fetching of a single annotation from a specific pod in a specific namespace. The path (.../metadata/annotation...) is intended to mirror the apimachinery API to avoid re-inventing especially assuming this might be expanded.

Given the leveraging of apimachinery, it made sense to add some additional endpoints:

* /namespaces/:namespace/pods/:name/metadata/annotations - when no :annotation is added (or is blank) all annotations are returned
* /namespaces/:namespace/pods/:name - pod details are returned for namspace/pod
* /namespaces/:namespace/pods - pod details are returned for all pods in namespace

Unmarshalling of annotations:

Since the specific goal is to help access scheduler-simulator annotations in a usable format, we attempt to unmarshal specific annotations.  A specific scheduler-simulator/* annotation will become map[string]map[string]string.

In addition, when :annotation = "scheduler-simulator" or "scheduler-simulator/" we can conclude that all the simulator annotations for this pod should be returned and unmarshalled into map[string]map[string]map[string]string.

Other cases dump all the metadata and do not unmarshal annotations to avoid errors.

Signed-off-by: Mark Sturdevant <mark.sturdevant@ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


/label tide/merge-method-squash
