### PR TITLE
Fix crash due to concurrent Pod mutation

### DIFF
--- a/simulator/scheduler/plugin/resultstore/store.go
+++ b/simulator/scheduler/plugin/resultstore/store.go
@@ -157,6 +157,9 @@ func (s *Store) addSchedulingResultToPod(_, newObj interface{}) {
 		return
 	}
 
+	// Make a copy so we don't mutate the object from the informer.
+	pod = pod.DeepCopy()
+
 	if err := s.addPreFilterResultToPod(pod); err != nil {
 		klog.Errorf("failed to add prefilter result to pod: %+v", err)
 		return

--- a/simulator/scheduler/plugin/resultstore/store_test.go
+++ b/simulator/scheduler/plugin/resultstore/store_test.go
@@ -587,7 +587,7 @@ func TestStore_addSchedulingResultToPod(t *testing.T) {
 		name                       string
 		result                     map[key]*result
 		prepareFakeClientSetFn     func() *fake.Clientset
-		newObj                     interface{}
+		newObj                     *corev1.Pod
 		wantpod                    *corev1.Pod
 		resultRemainsAfterExecFunc bool
 		wanterr                    bool
@@ -924,7 +924,12 @@ func TestStore_addSchedulingResultToPod(t *testing.T) {
 				results: tt.result,
 				client:  c,
 			}
+			original := tt.newObj.DeepCopy()
 			s.addSchedulingResultToPod(nil, tt.newObj)
+
+			// Check that the function doesn't mutate the input object,
+			// which is shared with other event handlers.
+			assert.Equal(t, original, tt.newObj)
 
 			if !tt.wanterr {
 				p, _ := c.CoreV1().Pods(namespace).Get(context.Background(), podName, metav1.GetOptions{})


### PR DESCRIPTION
We should make a copy instead of directly mutating the Pod that was sent by the informer.

This fixes a crash in the scheduler (https://github.com/kubernetes/kubernetes/issues/116226), which was trying to concurrently read the same Pod object we mutated.