### PR TITLE
feature(simulator): store previous scheduling result as a result history

### DIFF
--- a/simulator/scheduler/extender/mock_extender/resultstore.go
+++ b/simulator/scheduler/extender/mock_extender/resultstore.go
@@ -84,9 +84,11 @@ func (mr *MockStoreMockRecorder) AddPrioritizeResult(args, result, hostName inte
 }
 
 // AddStoredResultToPod mocks base method.
-func (m *MockStore) AddStoredResultToPod(pod *v1.Pod) {
+func (m *MockStore) AddStoredResultToPod(pod *v1.Pod) map[string]string {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddStoredResultToPod", pod)
+	ret := m.ctrl.Call(m, "AddStoredResultToPod", pod)
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
 }
 
 // AddStoredResultToPod indicates an expected call of AddStoredResultToPod.

--- a/simulator/scheduler/extender/mock_extender/resultstore.go
+++ b/simulator/scheduler/extender/mock_extender/resultstore.go
@@ -83,18 +83,18 @@ func (mr *MockStoreMockRecorder) AddPrioritizeResult(args, result, hostName inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPrioritizeResult", reflect.TypeOf((*MockStore)(nil).AddPrioritizeResult), args, result, hostName)
 }
 
-// AddStoredResultToPod mocks base method.
-func (m *MockStore) AddStoredResultToPod(pod *v1.Pod) map[string]string {
+// GetStoredResult mocks base method.
+func (m *MockStore) GetStoredResult(pod *v1.Pod) map[string]string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddStoredResultToPod", pod)
+	ret := m.ctrl.Call(m, "GetStoredResult", pod)
 	ret0, _ := ret[0].(map[string]string)
 	return ret0
 }
 
-// AddStoredResultToPod indicates an expected call of AddStoredResultToPod.
-func (mr *MockStoreMockRecorder) AddStoredResultToPod(pod interface{}) *gomock.Call {
+// GetStoredResult indicates an expected call of GetStoredResult.
+func (mr *MockStoreMockRecorder) GetStoredResult(pod interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddStoredResultToPod", reflect.TypeOf((*MockStore)(nil).AddStoredResultToPod), pod)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoredResult", reflect.TypeOf((*MockStore)(nil).GetStoredResult), pod)
 }
 
 // DeleteData mocks base method.

--- a/simulator/scheduler/extender/resultstore/resultstore.go
+++ b/simulator/scheduler/extender/resultstore/resultstore.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Store interface {
-	AddStoredResultToPod(pod *v1.Pod) map[string]string
+	GetStoredResult(pod *v1.Pod) map[string]string
 	DeleteData(pod v1.Pod)
 	AddFilterResult(args extenderv1.ExtenderArgs, result extenderv1.ExtenderFilterResult, hostName string)
 	AddPrioritizeResult(args extenderv1.ExtenderArgs, result extenderv1.HostPriorityList, hostName string)
@@ -66,8 +66,8 @@ func newData() *result {
 	}
 }
 
-// AddStoredResultToPod adds all data corresponding to the specified key to the pod.
-func (s *store) AddStoredResultToPod(pod *v1.Pod) map[string]string {
+// GetStoredResult get all stored result of a given Pod.
+func (s *store) GetStoredResult(pod *v1.Pod) map[string]string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -78,22 +78,22 @@ func (s *store) AddStoredResultToPod(pod *v1.Pod) map[string]string {
 	}
 
 	annotation := map[string]string{}
-	if err := s.addFilterResultToPod(annotation, k); err != nil {
+	if err := s.addFilterResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add filtering result to the pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addPrioritizeResultToPod(annotation, k); err != nil {
+	if err := s.addPrioritizeResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add prioritize result to the pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addPreemptResultToPod(annotation, k); err != nil {
+	if err := s.addPreemptResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add preempt result to the pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addBindResultToPod(annotation, k); err != nil {
+	if err := s.addBindResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add bind result to the pod: $+v", err)
 		return nil
 	}
@@ -101,7 +101,7 @@ func (s *store) AddStoredResultToPod(pod *v1.Pod) map[string]string {
 	return annotation
 }
 
-func (s *store) addFilterResultToPod(anno map[string]string, k key) error {
+func (s *store) addFilterResultToMap(anno map[string]string, k key) error {
 	results, err := json.Marshal(s.results[k].filter)
 	if err != nil {
 		return xerrors.Errorf("encode Filter results to json: %w", err)
@@ -110,7 +110,7 @@ func (s *store) addFilterResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *store) addPrioritizeResultToPod(anno map[string]string, k key) error {
+func (s *store) addPrioritizeResultToMap(anno map[string]string, k key) error {
 	results, err := json.Marshal(s.results[k].prioritize)
 	if err != nil {
 		return xerrors.Errorf("encode Prioritize results to json: %w", err)
@@ -119,7 +119,7 @@ func (s *store) addPrioritizeResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *store) addPreemptResultToPod(anno map[string]string, k key) error {
+func (s *store) addPreemptResultToMap(anno map[string]string, k key) error {
 	results, err := json.Marshal(s.results[k].preempt)
 	if err != nil {
 		return xerrors.Errorf("encode Preempt results to json: %w", err)
@@ -128,7 +128,7 @@ func (s *store) addPreemptResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *store) addBindResultToPod(anno map[string]string, k key) error {
+func (s *store) addBindResultToMap(anno map[string]string, k key) error {
 	results, err := json.Marshal(s.results[k].bind)
 	if err != nil {
 		return xerrors.Errorf("encode Bind results to json: %w", err)

--- a/simulator/scheduler/extender/resultstore/resultstore_test.go
+++ b/simulator/scheduler/extender/resultstore/resultstore_test.go
@@ -18,10 +18,10 @@ func TestStore_AddStoredResultToPod(t *testing.T) {
 	podName := "pod1"
 	namespace := "default"
 	tests := []struct {
-		name    string
-		result  map[key]*result
-		newObj  *corev1.Pod
-		wantPod *corev1.Pod
+		name           string
+		result         map[key]*result
+		newObj         *corev1.Pod
+		wantAnnotation map[string]string
 	}{
 		{
 			name: "success",
@@ -62,68 +62,56 @@ func TestStore_AddStoredResultToPod(t *testing.T) {
 					Namespace: namespace,
 				},
 			},
-			wantPod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      podName,
-					Namespace: namespace,
-					Annotations: map[string]string{
-						annotation.ExtenderFilterResultAnnotationKey: func() string {
-							r := map[string]extenderv1.ExtenderFilterResult{
-								"node0": {
-									Nodes:                      &corev1.NodeList{Items: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "nodename"}}}},
-									NodeNames:                  &[]string{"node1"},
-									FailedNodes:                map[string]string{"foo": "bar"},
-									FailedAndUnresolvableNodes: map[string]string{"baz": "qux"},
-									Error:                      "myerror",
-								},
-							}
-							d, _ := json.Marshal(r)
-							return string(d)
-						}(),
-						annotation.ExtenderPrioritizeResultAnnotationKey: func() string {
-							r := map[string]extenderv1.HostPriorityList{
-								"node0": {
-									{
-										Host:  "node1",
-										Score: 1.0,
-									},
-								},
-							}
-							d, _ := json.Marshal(r)
-							return string(d)
-						}(),
-						annotation.ExtenderPreemptResultAnnotationKey: func() string {
-							r := map[string]extenderv1.ExtenderPreemptionResult{
-								"node0": {
-									NodeNameToMetaVictims: map[string]*extenderv1.MetaVictims{"foo": {Pods: []*extenderv1.MetaPod{{UID: "myuid"}}, NumPDBViolations: 1}},
-								},
-							}
-							d, _ := json.Marshal(r)
-							return string(d)
-						}(),
-						annotation.ExtenderBindResultAnnotationKey: func() string {
-							r := map[string]extenderv1.ExtenderBindingResult{
-								"node0": {
-									Error: "myerror",
-								},
-							}
-							d, _ := json.Marshal(r)
-							return string(d)
-						}(),
-					},
-				},
+			wantAnnotation: map[string]string{
+				annotation.ExtenderFilterResultAnnotationKey: func() string {
+					r := map[string]extenderv1.ExtenderFilterResult{
+						"node0": {
+							Nodes:                      &corev1.NodeList{Items: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "nodename"}}}},
+							NodeNames:                  &[]string{"node1"},
+							FailedNodes:                map[string]string{"foo": "bar"},
+							FailedAndUnresolvableNodes: map[string]string{"baz": "qux"},
+							Error:                      "myerror",
+						},
+					}
+					d, _ := json.Marshal(r)
+					return string(d)
+				}(),
+				annotation.ExtenderPrioritizeResultAnnotationKey: func() string {
+					r := map[string]extenderv1.HostPriorityList{
+						"node0": {
+							{
+								Host:  "node1",
+								Score: 1.0,
+							},
+						},
+					}
+					d, _ := json.Marshal(r)
+					return string(d)
+				}(),
+				annotation.ExtenderPreemptResultAnnotationKey: func() string {
+					r := map[string]extenderv1.ExtenderPreemptionResult{
+						"node0": {
+							NodeNameToMetaVictims: map[string]*extenderv1.MetaVictims{"foo": {Pods: []*extenderv1.MetaPod{{UID: "myuid"}}, NumPDBViolations: 1}},
+						},
+					}
+					d, _ := json.Marshal(r)
+					return string(d)
+				}(),
+				annotation.ExtenderBindResultAnnotationKey: func() string {
+					r := map[string]extenderv1.ExtenderBindingResult{
+						"node0": {
+							Error: "myerror",
+						},
+					}
+					d, _ := json.Marshal(r)
+					return string(d)
+				}(),
 			},
 		},
 		{
 			name:   "do nothing if store doesn't have data",
 			result: map[key]*result{},
 			newObj: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      podName,
-					Namespace: namespace,
-				},
-			},
-			wantPod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      podName,
 					Namespace: namespace,
@@ -154,29 +142,23 @@ func TestStore_AddStoredResultToPod(t *testing.T) {
 					Namespace: namespace,
 				},
 			},
-			wantPod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      podName,
-					Namespace: namespace,
-					Annotations: map[string]string{
-						annotation.ExtenderFilterResultAnnotationKey: func() string {
-							r := map[string]extenderv1.ExtenderFilterResult{
-								"node0": {
-									Nodes:                      &corev1.NodeList{Items: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "nodename"}}}},
-									NodeNames:                  &[]string{"node1"},
-									FailedNodes:                map[string]string{"foo": "bar"},
-									FailedAndUnresolvableNodes: map[string]string{"baz": "qux"},
-									Error:                      "myerror",
-								},
-							}
-							d, _ := json.Marshal(r)
-							return string(d)
-						}(),
-						annotation.ExtenderPrioritizeResultAnnotationKey: "{}",
-						annotation.ExtenderPreemptResultAnnotationKey:    "{}",
-						annotation.ExtenderBindResultAnnotationKey:       "{}",
-					},
-				},
+			wantAnnotation: map[string]string{
+				annotation.ExtenderFilterResultAnnotationKey: func() string {
+					r := map[string]extenderv1.ExtenderFilterResult{
+						"node0": {
+							Nodes:                      &corev1.NodeList{Items: []corev1.Node{{ObjectMeta: metav1.ObjectMeta{Name: "nodename"}}}},
+							NodeNames:                  &[]string{"node1"},
+							FailedNodes:                map[string]string{"foo": "bar"},
+							FailedAndUnresolvableNodes: map[string]string{"baz": "qux"},
+							Error:                      "myerror",
+						},
+					}
+					d, _ := json.Marshal(r)
+					return string(d)
+				}(),
+				annotation.ExtenderPrioritizeResultAnnotationKey: "{}",
+				annotation.ExtenderPreemptResultAnnotationKey:    "{}",
+				annotation.ExtenderBindResultAnnotationKey:       "{}",
 			},
 		},
 	}
@@ -189,9 +171,9 @@ func TestStore_AddStoredResultToPod(t *testing.T) {
 				results: tt.result,
 			}
 			p := tt.newObj
-			s.AddStoredResultToPod(p)
+			result := s.AddStoredResultToPod(p)
 
-			assert.Equal(t, tt.wantPod, p)
+			assert.Equal(t, tt.wantAnnotation, result)
 		})
 	}
 }

--- a/simulator/scheduler/extender/resultstore/resultstore_test.go
+++ b/simulator/scheduler/extender/resultstore/resultstore_test.go
@@ -13,7 +13,7 @@ import (
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/extender/annotation"
 )
 
-func TestStore_AddStoredResultToPod(t *testing.T) {
+func TestStore_GetStoredResult(t *testing.T) {
 	t.Parallel()
 	podName := "pod1"
 	namespace := "default"
@@ -171,7 +171,7 @@ func TestStore_AddStoredResultToPod(t *testing.T) {
 				results: tt.result,
 			}
 			p := tt.newObj
-			result := s.AddStoredResultToPod(p)
+			result := s.GetStoredResult(p)
 
 			assert.Equal(t, tt.wantAnnotation, result)
 		})

--- a/simulator/scheduler/plugin/resultstore/store.go
+++ b/simulator/scheduler/plugin/resultstore/store.go
@@ -122,10 +122,10 @@ func newData() *result {
 	return d
 }
 
-// AddStoredResultToPod adds all data corresponding to the specified key to the pod.
+// GetStoredResult get all stored result of a given Pod.
 //
 //nolint:cyclop,funlen
-func (s *Store) AddStoredResultToPod(pod *v1.Pod) map[string]string {
+func (s *Store) GetStoredResult(pod *v1.Pod) map[string]string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -136,52 +136,52 @@ func (s *Store) AddStoredResultToPod(pod *v1.Pod) map[string]string {
 	}
 
 	annotation := map[string]string{}
-	if err := s.addPreFilterResultToPod(annotation, k); err != nil {
+	if err := s.addPreFilterResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add prefilter result to pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addFilterResultToPod(annotation, k); err != nil {
+	if err := s.addFilterResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add filtering result to pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addPostFilterResultToPod(annotation, k); err != nil {
+	if err := s.addPostFilterResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add post filtering result to pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addPreScoreResultToPod(annotation, k); err != nil {
+	if err := s.addPreScoreResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add prescore result to pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addScoreResultToPod(annotation, k); err != nil {
+	if err := s.addScoreResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add scoring result to pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addFinalScoreResultToPod(annotation, k); err != nil {
+	if err := s.addFinalScoreResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add final score result to pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addReserveResultToPod(annotation, k); err != nil {
+	if err := s.addReserveResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add reserve result to pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addPermitResultToPod(annotation, k); err != nil {
+	if err := s.addPermitResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add permit result to pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addPreBindResultToPod(annotation, k); err != nil {
+	if err := s.addPreBindResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add prebind result to pod: %+v", err)
 		return nil
 	}
 
-	if err := s.addBindResultToPod(annotation, k); err != nil {
+	if err := s.addBindResultToMap(annotation, k); err != nil {
 		klog.Errorf("failed to add bind result to pod: %+v", err)
 		return nil
 	}
@@ -191,7 +191,7 @@ func (s *Store) AddStoredResultToPod(pod *v1.Pod) map[string]string {
 	return annotation
 }
 
-func (s *Store) addPreFilterResultToPod(anno map[string]string, k key) error {
+func (s *Store) addPreFilterResultToMap(anno map[string]string, k key) error {
 	_, ok := anno[annotation.PreFilterResultAnnotationKey]
 	if !ok {
 		if s.results[k].preFilterResult == nil {
@@ -223,7 +223,7 @@ func (s *Store) addPreFilterResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *Store) addPreScoreResultToPod(anno map[string]string, k key) error {
+func (s *Store) addPreScoreResultToMap(anno map[string]string, k key) error {
 	_, ok := anno[annotation.PreScoreResultAnnotationKey]
 	if ok {
 		return nil
@@ -241,7 +241,7 @@ func (s *Store) addPreScoreResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *Store) addBindResultToPod(anno map[string]string, k key) error {
+func (s *Store) addBindResultToMap(anno map[string]string, k key) error {
 	_, ok := anno[annotation.BindResultAnnotationKey]
 	if ok {
 		return nil
@@ -259,7 +259,7 @@ func (s *Store) addBindResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *Store) addPreBindResultToPod(anno map[string]string, k key) error {
+func (s *Store) addPreBindResultToMap(anno map[string]string, k key) error {
 	_, ok := anno[annotation.PreBindResultAnnotationKey]
 	if ok {
 		return nil
@@ -286,7 +286,7 @@ func (s *Store) addSelectedNodeToPod(anno map[string]string, k key) {
 	anno[annotation.SelectedNodeAnnotationKey] = s.results[k].selectedNode
 }
 
-func (s *Store) addReserveResultToPod(anno map[string]string, k key) error {
+func (s *Store) addReserveResultToMap(anno map[string]string, k key) error {
 	_, ok := anno[annotation.ReserveResultAnnotationKey]
 	if ok {
 		return nil
@@ -303,7 +303,7 @@ func (s *Store) addReserveResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *Store) addPermitResultToPod(anno map[string]string, k key) error {
+func (s *Store) addPermitResultToMap(anno map[string]string, k key) error {
 	_, ok := anno[annotation.PermitTimeoutResultAnnotationKey]
 	if !ok {
 		if s.results[k].permitTimeout == nil {
@@ -332,7 +332,7 @@ func (s *Store) addPermitResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *Store) addFilterResultToPod(anno map[string]string, k key) error {
+func (s *Store) addFilterResultToMap(anno map[string]string, k key) error {
 	_, ok := anno[annotation.FilterResultAnnotationKey]
 	if ok {
 		return nil
@@ -350,7 +350,7 @@ func (s *Store) addFilterResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *Store) addPostFilterResultToPod(anno map[string]string, k key) error {
+func (s *Store) addPostFilterResultToMap(anno map[string]string, k key) error {
 	_, ok := anno[annotation.PostFilterResultAnnotationKey]
 	if ok {
 		return nil
@@ -367,7 +367,7 @@ func (s *Store) addPostFilterResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *Store) addScoreResultToPod(anno map[string]string, k key) error {
+func (s *Store) addScoreResultToMap(anno map[string]string, k key) error {
 	_, ok := anno[annotation.ScoreResultAnnotationKey]
 	if ok {
 		return nil
@@ -385,7 +385,7 @@ func (s *Store) addScoreResultToPod(anno map[string]string, k key) error {
 	return nil
 }
 
-func (s *Store) addFinalScoreResultToPod(anno map[string]string, k key) error {
+func (s *Store) addFinalScoreResultToMap(anno map[string]string, k key) error {
 	_, ok := anno[annotation.FinalScoreResultAnnotationKey]
 	if ok {
 		return nil

--- a/simulator/scheduler/plugin/resultstore/store_test.go
+++ b/simulator/scheduler/plugin/resultstore/store_test.go
@@ -582,10 +582,10 @@ func TestStore_AddStoredResultToPod(t *testing.T) {
 	podName := "pod1"
 	namespace := "default"
 	tests := []struct {
-		name    string
-		result  map[key]*result
-		newObj  *corev1.Pod
-		wantpod *corev1.Pod
+		name           string
+		result         map[key]*result
+		newObj         *corev1.Pod
+		wantAnnotation map[string]string
 	}{
 		{
 			name: "success",
@@ -654,120 +654,108 @@ func TestStore_AddStoredResultToPod(t *testing.T) {
 					Namespace: namespace,
 				},
 			},
-			wantpod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      podName,
-					Namespace: namespace,
-					Annotations: map[string]string{
-						annotation.SelectedNodeAnnotationKey: "node",
-						annotation.PreScoreResultAnnotationKey: func() string {
-							d, _ := json.Marshal(map[string]string{
-								"plugin1": "preScore",
-							})
-							return string(d)
-						}(),
-						annotation.PreFilterResultAnnotationKey: func() string {
-							d, _ := json.Marshal(map[string][]string{
-								"plugin1": {"node1", "node2"},
-							})
-							return string(d)
-						}(),
-						annotation.PreFilterStatusResultAnnotationKey: func() string {
-							d, _ := json.Marshal(map[string]string{
-								"plugin1": "preFilterStatus",
-							})
-							return string(d)
-						}(),
-						annotation.PermitStatusResultAnnotationKey: func() string {
-							d, _ := json.Marshal(map[string]string{
-								"plugin1": "permit",
-							})
-							return string(d)
-						}(),
-						annotation.PermitTimeoutResultAnnotationKey: func() string {
-							d, _ := json.Marshal(map[string]string{
-								"plugin1": "1s",
-							})
-							return string(d)
-						}(),
-						annotation.ReserveResultAnnotationKey: func() string {
-							d, _ := json.Marshal(map[string]string{
-								"plugin1": "reserve",
-							})
-							return string(d)
-						}(),
-						annotation.PreBindResultAnnotationKey: func() string {
-							d, _ := json.Marshal(map[string]string{
-								"plugin1": "prebind",
-							})
-							return string(d)
-						}(),
-						annotation.BindResultAnnotationKey: func() string {
-							d, _ := json.Marshal(map[string]string{
-								"plugin1": "bind",
-							})
-							return string(d)
-						}(),
-						annotation.FilterResultAnnotationKey: func() string {
-							r := map[string]map[string]string{
-								"node0": {
-									"plugin1": PassedFilterMessage,
-								},
-								"node1": {
-									"plugin1": PassedFilterMessage,
-								},
-							}
-							d, _ := json.Marshal(r)
-							return string(d)
-						}(),
-						annotation.ScoreResultAnnotationKey: func() string {
-							r := map[string]map[string]string{
-								"node0": {
-									"plugin1": "10",
-								},
-								"node1": {
-									"plugin1": "10",
-								},
-							}
-							d, _ := json.Marshal(r)
-							return string(d)
-						}(),
-						annotation.FinalScoreResultAnnotationKey: func() string {
-							r := map[string]map[string]string{
-								"node0": {
-									"plugin1": "20",
-								},
-								"node1": {
-									"plugin1": "20",
-								},
-							}
-							d, _ := json.Marshal(r)
-							return string(d)
-						}(),
-						annotation.PostFilterResultAnnotationKey: func() string {
-							r := map[string]map[string]string{
-								"node0": {
-									"plugin1": PostFilterNominatedMessage,
-								},
-								"node1": {},
-							}
-							d, _ := json.Marshal(r)
-							return string(d)
-						}(),
-					},
-				},
+			wantAnnotation: map[string]string{
+				annotation.SelectedNodeAnnotationKey: "node",
+				annotation.PreScoreResultAnnotationKey: func() string {
+					d, _ := json.Marshal(map[string]string{
+						"plugin1": "preScore",
+					})
+					return string(d)
+				}(),
+				annotation.PreFilterResultAnnotationKey: func() string {
+					d, _ := json.Marshal(map[string][]string{
+						"plugin1": {"node1", "node2"},
+					})
+					return string(d)
+				}(),
+				annotation.PreFilterStatusResultAnnotationKey: func() string {
+					d, _ := json.Marshal(map[string]string{
+						"plugin1": "preFilterStatus",
+					})
+					return string(d)
+				}(),
+				annotation.PermitStatusResultAnnotationKey: func() string {
+					d, _ := json.Marshal(map[string]string{
+						"plugin1": "permit",
+					})
+					return string(d)
+				}(),
+				annotation.PermitTimeoutResultAnnotationKey: func() string {
+					d, _ := json.Marshal(map[string]string{
+						"plugin1": "1s",
+					})
+					return string(d)
+				}(),
+				annotation.ReserveResultAnnotationKey: func() string {
+					d, _ := json.Marshal(map[string]string{
+						"plugin1": "reserve",
+					})
+					return string(d)
+				}(),
+				annotation.PreBindResultAnnotationKey: func() string {
+					d, _ := json.Marshal(map[string]string{
+						"plugin1": "prebind",
+					})
+					return string(d)
+				}(),
+				annotation.BindResultAnnotationKey: func() string {
+					d, _ := json.Marshal(map[string]string{
+						"plugin1": "bind",
+					})
+					return string(d)
+				}(),
+				annotation.FilterResultAnnotationKey: func() string {
+					r := map[string]map[string]string{
+						"node0": {
+							"plugin1": PassedFilterMessage,
+						},
+						"node1": {
+							"plugin1": PassedFilterMessage,
+						},
+					}
+					d, _ := json.Marshal(r)
+					return string(d)
+				}(),
+				annotation.ScoreResultAnnotationKey: func() string {
+					r := map[string]map[string]string{
+						"node0": {
+							"plugin1": "10",
+						},
+						"node1": {
+							"plugin1": "10",
+						},
+					}
+					d, _ := json.Marshal(r)
+					return string(d)
+				}(),
+				annotation.FinalScoreResultAnnotationKey: func() string {
+					r := map[string]map[string]string{
+						"node0": {
+							"plugin1": "20",
+						},
+						"node1": {
+							"plugin1": "20",
+						},
+					}
+					d, _ := json.Marshal(r)
+					return string(d)
+				}(),
+				annotation.PostFilterResultAnnotationKey: func() string {
+					r := map[string]map[string]string{
+						"node0": {
+							"plugin1": PostFilterNominatedMessage,
+						},
+						"node1": {},
+					}
+					d, _ := json.Marshal(r)
+					return string(d)
+				}(),
 			},
 		},
 		{
 			name:   "do nothing if store doesn't have data",
 			result: map[key]*result{},
 			newObj: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      podName,
-					Namespace: namespace,
-				},
-			},
-			wantpod: &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      podName,
 					Namespace: namespace,
@@ -797,37 +785,31 @@ func TestStore_AddStoredResultToPod(t *testing.T) {
 					Namespace: namespace,
 				},
 			},
-			wantpod: &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      podName,
-					Namespace: namespace,
-					Annotations: map[string]string{
-						annotation.FilterResultAnnotationKey: func() string {
-							r := map[string]map[string]string{
-								"node0": {
-									"plugin1": PassedFilterMessage,
-								},
-								"node1": {
-									"plugin1": PassedFilterMessage,
-								},
-							}
-							d, _ := json.Marshal(r)
-							return string(d)
-						}(),
-						annotation.ScoreResultAnnotationKey:           "{}",
-						annotation.FinalScoreResultAnnotationKey:      "{}",
-						annotation.PostFilterResultAnnotationKey:      "{}",
-						annotation.SelectedNodeAnnotationKey:          "",
-						annotation.PreScoreResultAnnotationKey:        "{}",
-						annotation.PreFilterResultAnnotationKey:       "{}",
-						annotation.PreFilterStatusResultAnnotationKey: "{}",
-						annotation.PermitStatusResultAnnotationKey:    "{}",
-						annotation.PermitTimeoutResultAnnotationKey:   "{}",
-						annotation.ReserveResultAnnotationKey:         "{}",
-						annotation.PreBindResultAnnotationKey:         "{}",
-						annotation.BindResultAnnotationKey:            "{}",
-					},
-				},
+			wantAnnotation: map[string]string{
+				annotation.FilterResultAnnotationKey: func() string {
+					r := map[string]map[string]string{
+						"node0": {
+							"plugin1": PassedFilterMessage,
+						},
+						"node1": {
+							"plugin1": PassedFilterMessage,
+						},
+					}
+					d, _ := json.Marshal(r)
+					return string(d)
+				}(),
+				annotation.ScoreResultAnnotationKey:           "{}",
+				annotation.FinalScoreResultAnnotationKey:      "{}",
+				annotation.PostFilterResultAnnotationKey:      "{}",
+				annotation.SelectedNodeAnnotationKey:          "",
+				annotation.PreScoreResultAnnotationKey:        "{}",
+				annotation.PreFilterResultAnnotationKey:       "{}",
+				annotation.PreFilterStatusResultAnnotationKey: "{}",
+				annotation.PermitStatusResultAnnotationKey:    "{}",
+				annotation.PermitTimeoutResultAnnotationKey:   "{}",
+				annotation.ReserveResultAnnotationKey:         "{}",
+				annotation.PreBindResultAnnotationKey:         "{}",
+				annotation.BindResultAnnotationKey:            "{}",
 			},
 		},
 	}
@@ -840,9 +822,8 @@ func TestStore_AddStoredResultToPod(t *testing.T) {
 				results: tt.result,
 			}
 			p := tt.newObj
-			s.AddStoredResultToPod(p)
-
-			assert.Equal(t, tt.wantpod, p)
+			result := s.AddStoredResultToPod(p)
+			assert.Equal(t, tt.wantAnnotation, result)
 		})
 	}
 }

--- a/simulator/scheduler/plugin/resultstore/store_test.go
+++ b/simulator/scheduler/plugin/resultstore/store_test.go
@@ -577,7 +577,7 @@ func TestStore_AddNormalizedScoreResult(t *testing.T) {
 	}
 }
 
-func TestStore_AddStoredResultToPod(t *testing.T) {
+func TestStore_GetStoredResult(t *testing.T) {
 	t.Parallel()
 	podName := "pod1"
 	namespace := "default"
@@ -822,7 +822,7 @@ func TestStore_AddStoredResultToPod(t *testing.T) {
 				results: tt.result,
 			}
 			p := tt.newObj
-			result := s.AddStoredResultToPod(p)
+			result := s.GetStoredResult(p)
 			assert.Equal(t, tt.wantAnnotation, result)
 		})
 	}

--- a/simulator/scheduler/storereflector/annotation.go
+++ b/simulator/scheduler/storereflector/annotation.go
@@ -1,0 +1,4 @@
+package storereflector
+
+// ResultsHistoryAnnotation has the all results including the past ones.
+const ResultsHistoryAnnotation = "scheduler-simulator/result-history"

--- a/simulator/scheduler/storereflector/mock_storereflector/resultstore.go
+++ b/simulator/scheduler/storereflector/mock_storereflector/resultstore.go
@@ -34,18 +34,18 @@ func (m *MockResultStore) EXPECT() *MockResultStoreMockRecorder {
 	return m.recorder
 }
 
-// AddStoredResultToPod mocks base method.
-func (m *MockResultStore) AddStoredResultToPod(arg0 *v1.Pod) map[string]string {
+// GetStoredResult mocks base method.
+func (m *MockResultStore) GetStoredResult(arg0 *v1.Pod) map[string]string {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddStoredResultToPod", arg0)
+	ret := m.ctrl.Call(m, "GetStoredResult", arg0)
 	ret0, _ := ret[0].(map[string]string)
 	return ret0
 }
 
-// AddStoredResultToPod indicates an expected call of AddStoredResultToPod.
-func (mr *MockResultStoreMockRecorder) AddStoredResultToPod(arg0 interface{}) *gomock.Call {
+// GetStoredResult indicates an expected call of GetStoredResult.
+func (mr *MockResultStoreMockRecorder) GetStoredResult(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddStoredResultToPod", reflect.TypeOf((*MockResultStore)(nil).AddStoredResultToPod), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStoredResult", reflect.TypeOf((*MockResultStore)(nil).GetStoredResult), arg0)
 }
 
 // DeleteData mocks base method.

--- a/simulator/scheduler/storereflector/mock_storereflector/resultstore.go
+++ b/simulator/scheduler/storereflector/mock_storereflector/resultstore.go
@@ -35,9 +35,11 @@ func (m *MockResultStore) EXPECT() *MockResultStoreMockRecorder {
 }
 
 // AddStoredResultToPod mocks base method.
-func (m *MockResultStore) AddStoredResultToPod(arg0 *v1.Pod) {
+func (m *MockResultStore) AddStoredResultToPod(arg0 *v1.Pod) map[string]string {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AddStoredResultToPod", arg0)
+	ret := m.ctrl.Call(m, "AddStoredResultToPod", arg0)
+	ret0, _ := ret[0].(map[string]string)
+	return ret0
 }
 
 // AddStoredResultToPod indicates an expected call of AddStoredResultToPod.

--- a/simulator/scheduler/storereflector/storereflector.go
+++ b/simulator/scheduler/storereflector/storereflector.go
@@ -69,6 +69,8 @@ func (s *reflector) ResisterResultSavingToInformer(informerFactory informers.Sha
 
 // storeAllResultToPodFunc returns the function that reflects all results on the pod annotation when the scheduling is finished.
 // It will be used as the even handler of resource updating.
+//
+//nolint:funlen,gocognit,cyclop
 func (s *reflector) storeAllResultToPodFunc(client clientset.Interface) func(interface{}, interface{}) {
 	return func(_, newObj interface{}) {
 		ctx := context.Background()
@@ -107,7 +109,7 @@ func (s *reflector) storeAllResultToPodFunc(client clientset.Interface) func(int
 			}
 			if len(resultSet) == 0 {
 				// no need to update anything on the Pod.
-				return
+				return true, nil
 			}
 
 			if err := updateResultHistory(pod, resultSet); err != nil {

--- a/simulator/scheduler/storereflector/storereflector.go
+++ b/simulator/scheduler/storereflector/storereflector.go
@@ -28,8 +28,8 @@ type Reflector interface {
 // Fulfilling this interface will allow the stored results to be saved as data in that Pod
 // when the Pod's schedule is complete.
 type ResultStore interface {
-	// AddStoredResultToPod adds all data corresponding to the pod to the pod.
-	AddStoredResultToPod(pod *corev1.Pod) map[string]string
+	// GetStoredResult adds all data corresponding to the pod to the pod.
+	GetStoredResult(pod *corev1.Pod) map[string]string
 	// DeleteData deletes all data corresponding to the pod.
 	DeleteData(key corev1.Pod)
 }
@@ -94,11 +94,11 @@ func (s *reflector) storeAllResultToPodFunc(client clientset.Interface) func(int
 			// overwrite the Pod object so that we won't modify the copy from the shared informer.
 			pod = newPod
 
-			// Call AddStoredResultToPod of all ResultStore which is added to the map
+			// Call GetStoredResult of all ResultStore which is added to the map
 			// to reflects all results on the pod annotation.
 			resultSet := map[string]string{}
 			for k := range s.resultStores {
-				m := s.resultStores[k].AddStoredResultToPod(pod)
+				m := s.resultStores[k].GetStoredResult(pod)
 				for k, v := range m {
 					resultSet[k] = v
 					if pod.ObjectMeta.Annotations == nil {

--- a/simulator/scheduler/storereflector/storereflector.go
+++ b/simulator/scheduler/storereflector/storereflector.go
@@ -28,7 +28,7 @@ type Reflector interface {
 // Fulfilling this interface will allow the stored results to be saved as data in that Pod
 // when the Pod's schedule is complete.
 type ResultStore interface {
-	// GetStoredResult adds all data corresponding to the pod to the pod.
+	// GetStoredResult get all stored result of a given Pod.
 	GetStoredResult(pod *corev1.Pod) map[string]string
 	// DeleteData deletes all data corresponding to the pod.
 	DeleteData(key corev1.Pod)
@@ -94,8 +94,8 @@ func (s *reflector) storeAllResultToPodFunc(client clientset.Interface) func(int
 			// overwrite the Pod object so that we won't modify the copy from the shared informer.
 			pod = newPod
 
-			// Call GetStoredResult of all ResultStore which is added to the map
-			// to reflects all results on the pod annotation.
+			// Call GetStoredResult of all ResultStore which is kept on the map
+			// to reflect all results to the pod annotation.
 			resultSet := map[string]string{}
 			for k := range s.resultStores {
 				m := s.resultStores[k].GetStoredResult(pod)

--- a/simulator/scheduler/storereflector/storereflector_test.go
+++ b/simulator/scheduler/storereflector/storereflector_test.go
@@ -36,7 +36,7 @@ func TestReflector_storeAllResultToPodFunc(t *testing.T) {
 			podName:      "pod1",
 			podNamespace: "default",
 			prepareMockResultStoreSetFn: func(m *mock_storereflector.MockResultStore) {
-				m.EXPECT().AddStoredResultToPod(gomock.Any()).Return(map[string]string{ExtenderFilterResultAnnotationKey: "some results"})
+				m.EXPECT().GetStoredResult(gomock.Any()).Return(map[string]string{ExtenderFilterResultAnnotationKey: "some results"})
 				m.EXPECT().DeleteData(gomock.Any())
 			},
 			prepareFakeClientSetFn: func() *fake.Clientset {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

So far, we only record the latest scheduling result. 
This PR store the past ones in `scheduler-simulator/result-history` annotation in a list.
This PR doesn't delete the previous annotations, they'll remain as showing the latest results.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #214

#### Special notes for your reviewer:

annotation gonna be like:

```
    scheduler-simulator/result-history: >-
      [{"scheduler-simulator/bind-result":"{}","scheduler-simulator/filter-result":"{\"node-6jp9b\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"Insufficient
      memory\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"},\"node-lgpp8\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"Insufficient
      memory\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"}}","scheduler-simulator/finalscore-result":"{}","scheduler-simulator/permit-result":"{}","scheduler-simulator/permit-result-timeout":"{}","scheduler-simulator/postfilter-result":"{\"node-6jp9b\":{},\"node-lgpp8\":{}}","scheduler-simulator/prebind-result":"{}","scheduler-simulator/prefilter-result":"{}","scheduler-simulator/prefilter-result-status":"{\"InterPodAffinity\":\"success\",\"NodeAffinity\":\"success\",\"NodePorts\":\"success\",\"NodeResourcesFit\":\"success\",\"PodTopologySpread\":\"success\",\"VolumeBinding\":\"success\",\"VolumeRestrictions\":\"success\"}","scheduler-simulator/prescore-result":"{}","scheduler-simulator/reserve-result":"{}","scheduler-simulator/score-result":"{}","scheduler-simulator/selected-node":""},{"scheduler-simulator/bind-result":"{\"DefaultBinder\":\"success\"}","scheduler-simulator/filter-result":"{\"node-6jp9b\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"Insufficient
      memory\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"},\"node-lgpp8\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"Insufficient
      memory\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"},\"node-sbxkb\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"passed\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"}}","scheduler-simulator/finalscore-result":"{}","scheduler-simulator/permit-result":"{}","scheduler-simulator/permit-result-timeout":"{}","scheduler-simulator/postfilter-result":"{\"node-6jp9b\":{},\"node-lgpp8\":{}}","scheduler-simulator/prebind-result":"{\"VolumeBinding\":\"success\"}","scheduler-simulator/prefilter-result":"{}","scheduler-simulator/prefilter-result-status":"{\"InterPodAffinity\":\"success\",\"NodeAffinity\":\"success\",\"NodePorts\":\"success\",\"NodeResourcesFit\":\"success\",\"PodTopologySpread\":\"success\",\"VolumeBinding\":\"success\",\"VolumeRestrictions\":\"success\"}","scheduler-simulator/prescore-result":"{}","scheduler-simulator/reserve-result":"{\"VolumeBinding\":\"success\"}","scheduler-simulator/score-result":"{}","scheduler-simulator/selected-node":"node-sbxkb"}]
```


/label tide/merge-method-squash
