### PR TITLE
Replace k8s.gcr.io with registry.k8s.io

### DIFF
--- a/web/components/lib/templates/pod.yaml
+++ b/web/components/lib/templates/pod.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   containers:
     - name: pause
-      image: k8s.gcr.io/pause:3.5
+      image: registry.k8s.io/pause:3.5
       resources:
         limits:
           cpu: 100m


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR replaces all `k8s.gcr.io` references with `registry.k8s.io`. See the linked issue for more details.

**Which issue(s) this PR fixes**:
xref https://github.com/kubernetes/k8s.io/issues/4738

**Release note**:
```
Replace all `k8s.gcr.io` references with `registry.k8s.io`
```