### PR TITLE
BugFix: some wrappedPlugin returns non suit status

### DIFF
--- a/simulator/scheduler/plugin/wrappedplugin.go
+++ b/simulator/scheduler/plugin/wrappedplugin.go
@@ -517,8 +517,8 @@ func (w *wrappedPlugin) Filter(ctx context.Context, state *framework.CycleState,
 
 func (w *wrappedPlugin) PostFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, filteredNodeStatusMap framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status) {
 	if w.originalPostFilterPlugin == nil {
-		// return nil not to affect post filtering.
-		return nil, nil
+		// return Unschedulable not to affect post filtering.
+		return nil, framework.NewStatus(framework.Unschedulable)
 	}
 	if w.postFilterPluginExtender != nil {
 		r, s := w.postFilterPluginExtender.BeforePostFilter(ctx, state, pod, filteredNodeStatusMap)
@@ -665,8 +665,8 @@ func (w *wrappedPlugin) PreBind(ctx context.Context, state *framework.CycleState
 
 func (w *wrappedPlugin) Bind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodename string) *framework.Status {
 	if w.originalBindPlugin == nil {
-		// return nil not to affect scoring
-		return nil
+		// return skip not to affect scoring
+		return framework.NewStatus(framework.Skip, "called wrapped buind plugin is nil")
 	}
 
 	if w.bindPluginExtender != nil {

--- a/simulator/scheduler/plugin/wrappedplugin.go
+++ b/simulator/scheduler/plugin/wrappedplugin.go
@@ -518,6 +518,7 @@ func (w *wrappedPlugin) Filter(ctx context.Context, state *framework.CycleState,
 func (w *wrappedPlugin) PostFilter(ctx context.Context, state *framework.CycleState, pod *v1.Pod, filteredNodeStatusMap framework.NodeToStatusMap) (*framework.PostFilterResult, *framework.Status) {
 	if w.originalPostFilterPlugin == nil {
 		// return Unschedulable not to affect post filtering.
+		// (If return Unschedulable, the scheduler will execute next PostFilter plugin.)
 		return nil, framework.NewStatus(framework.Unschedulable)
 	}
 	if w.postFilterPluginExtender != nil {
@@ -665,8 +666,8 @@ func (w *wrappedPlugin) PreBind(ctx context.Context, state *framework.CycleState
 
 func (w *wrappedPlugin) Bind(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodename string) *framework.Status {
 	if w.originalBindPlugin == nil {
-		// return skip not to affect scoring
-		return framework.NewStatus(framework.Skip, "called wrapped buind plugin is nil")
+		// return skip not to affect other bind plugins.
+		return framework.NewStatus(framework.Skip, "called wrapped bind plugin is nil")
 	}
 
 	if w.bindPluginExtender != nil {

--- a/simulator/scheduler/plugin/wrappedplugin_test.go
+++ b/simulator/scheduler/plugin/wrappedplugin_test.go
@@ -1863,7 +1863,7 @@ func Test_wrappedPlugin_Bind(t *testing.T) {
 		{
 			name:       "unhappy: it is not bind plugin",
 			noExtender: true,
-			want:       framework.NewStatus(framework.Skip, "called wrapped buind plugin is nil"),
+			want:       framework.NewStatus(framework.Skip, "called wrapped bind plugin is nil"),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/area simulator
/kind bug
<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Some wrappedPlugin returns nonsuit status if it does not support the extension point.
This caused the first and subsequent plugins to no called if more than one plugin was set for that extension point. This caused the first and subsequent plugins to no called if more than one plugin was set for that extension point.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


/label tide/merge-method-squash
/assign @sanposhiho 