### PR TITLE
Replace api/v1/namespaces//pods with api/v1/pods

### DIFF
--- a/web/api/v1/pod.ts
+++ b/web/api/v1/pod.ts
@@ -56,7 +56,7 @@ export default function podAPI(k8sInstance: AxiosInstance) {
       try {
         // This URL path could list all pods on each namespace.
         const res = await k8sInstance.get<V1PodList>(
-          "namespaces//pods",
+          "pods",
           {}
         );
         return res.data;

--- a/web/api/v1/pvc.ts
+++ b/web/api/v1/pvc.ts
@@ -59,7 +59,7 @@ export default function pvcAPI(k8sInstance: AxiosInstance) {
       try {
         // This URL path could list all pods on each namespace.
         const res = await k8sInstance.get<V1PersistentVolumeClaimList>(
-          "namespaces//persistentvolumeclaims",
+          "persistentvolumeclaims",
           {}
         );
         return res.data;


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/area web
<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
I am trying to integrate kube-scheduler-simulator with a real Kubernetes cluster. And I found the correct API to retrieve all pods is api/v1/pods instead of api/v1/namespaces//pods in some versions of kube-apiserver.
```
$ curl http://localhost:3131/api/v1/namespaces//pods
<a href="/api/v1/namespaces/pods">Moved Permanently</a>.
```

```
$ curl http://localhost:3131/api/v1/pods
{
  "kind": "PodList",
  "apiVersion": "v1",
  "metadata": {
    "resourceVersion": "121823"
  },
  "items": [
    {
      "metadata": {
        "name": "nginx-pod",
        "namespace": "default",
        "uid": "44b6bc4e-ad5e-4794-94ed-2879d2d05486",
        "resourceVersion": "57267",
        "creationTimestamp": "2023-07-21T16:22:52Z",
...
```
So i thinks replacement `api/v1/namespaces//pods` with `api/v1/pods` is a good way.
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #312 #290 

#### Special notes for your reviewer:


/label tide/merge-method-squash
