### PR TITLE
Use correct log function in NodeNumber

### DIFF
--- a/simulator/docs/sample/nodenumber/plugin.go
+++ b/simulator/docs/sample/nodenumber/plugin.go
@@ -57,7 +57,7 @@ func (s *preScoreState) Clone() framework.StateData {
 }
 
 func (pl *NodeNumber) PreScore(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodes []*v1.Node) *framework.Status {
-	klog.Info("execute PreScore on NodeNumber plugin", "pod", klog.KObj(pod))
+	klog.InfoS("execute PreScore on NodeNumber plugin", "pod", klog.KObj(pod))
 
 	podNameLastChar := pod.Name[len(pod.Name)-1:]
 	podnum, err := strconv.Atoi(podNameLastChar)
@@ -84,7 +84,7 @@ var ErrNotExpectedPreScoreState = errors.New("unexpected pre score state")
 
 // Score invoked at the score extension point.
 func (pl *NodeNumber) Score(ctx context.Context, state *framework.CycleState, pod *v1.Pod, nodeName string) (int64, *framework.Status) {
-	klog.Info("execute Score on NodeNumber plugin", "pod", klog.KObj(pod))
+	klog.InfoS("execute Score on NodeNumber plugin", "pod", klog.KObj(pod))
 	data, err := state.Read(preScoreStateKey)
 	if err != nil {
 		// return success even if there is no value in preScoreStateKey, since the


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

In the NodeNumber example, `klog.Info` was used when `klog.InfoS` was meant to be used.

#### Which issue(s) this PR fixes:

NONE

#### Special notes for your reviewer:


/label tide/merge-method-squash
