### PR TITLE
Support extender on external scheduler

### DIFF
--- a/simulator/pkg/debuggablescheduler/command.go
+++ b/simulator/pkg/debuggablescheduler/command.go
@@ -2,9 +2,11 @@ package debuggablescheduler
 
 import (
 	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/extender"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/plugin"
 )
 
@@ -13,15 +15,36 @@ func NewSchedulerCommand(opts ...Option) (*cobra.Command, func(), error) {
 	for _, o := range opts {
 		o(opt)
 	}
+	configs, err := NewConfigs()
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to NewConfigs(): %w", err)
+	}
 
-	scheduleropts, cancelFn, err := CreateOptionForOutOfTreePlugin(opt.outOfTreeRegistry, opt.pluginExtender)
+	// Extender service must be initialized using `KubeSchedulerConfiguration.Extenders` config which is not override for simulator (before calling OverrideExtendersCfgToSimulator()).
+	// The override will be do within CreateOptions().
+	extenderService, err := extender.New(configs.clientSet, configs.versioned.Extenders, configs.sharedStore)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("failed to New Extender service: %w", err)
+	}
+
+	schedulerOpts, cancelFn, err := CreateOptions(configs, opt.outOfTreeRegistry, opt.pluginExtender)
 	if err != nil {
 		return nil, cancelFn, err
 	}
+	// Launch the proxy HTTP server for Extender, which is used to store the Extender's results.
+	s := NewExtenderServer(extenderService)
+	shutdownFn, err := s.Start(configs.port)
+	if err != nil {
+		return nil, nil, xerrors.Errorf("start extender proxy server: %w", err)
+	}
 
-	command := app.NewSchedulerCommand(scheduleropts...)
+	cancel := func() {
+		cancelFn()
+		shutdownFn()
+	}
+	command := app.NewSchedulerCommand(schedulerOpts...)
 
-	return command, cancelFn, nil
+	return command, cancel, nil
 }
 
 type options struct {

--- a/simulator/pkg/debuggablescheduler/debuggable_scheduler.go
+++ b/simulator/pkg/debuggablescheduler/debuggable_scheduler.go
@@ -121,7 +121,7 @@ func CreateOptions(configs Configs, outOfTreePluginRegistry runtime.Registry, pl
 }
 
 // CreateOptionForPlugin creates Option for in/out of tree plugins.
-// It does create the wrapped plugin registries and return the registries as app.Option
+// It does create the wrapped plugin registries and return the registries as app.Option.
 func CreateOptionForPlugin(outOfTreePluginRegistry runtime.Registry, pluginExtender map[string]plugin.PluginExtenderInitializer, sharedStore storereflector.Reflector, internalCfg *config.KubeSchedulerConfiguration) ([]app.Option, error) {
 	if outOfTreePluginRegistry != nil {
 		// This must be called before plugin.NewRegistry().

--- a/simulator/pkg/debuggablescheduler/server.go
+++ b/simulator/pkg/debuggablescheduler/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/labstack/gommon/log"
 	"golang.org/x/xerrors"
+
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/extender"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/server"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/server/handler"

--- a/simulator/pkg/debuggablescheduler/server.go
+++ b/simulator/pkg/debuggablescheduler/server.go
@@ -1,0 +1,59 @@
+package debuggablescheduler
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/labstack/gommon/log"
+	"golang.org/x/xerrors"
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/extender"
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/server"
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/server/handler"
+)
+
+// ExtenderServer is proxy server for extender.
+type ExtenderServer struct {
+	e *echo.Echo
+}
+
+// NewExtenderServer initialize ExtenderServer.
+// This server is used as a proxy server to store Extender results.
+func NewExtenderServer(service *extender.Service) ExtenderServer {
+	e := echo.New()
+	e.Use(middleware.Logger())
+
+	extenderHandler := handler.NewExtenderHandler(service)
+	// register apis
+	v1 := e.Group("/api/v1")
+	server.RouteExtender(v1, extenderHandler)
+	s := ExtenderServer{e: e}
+	s.e.Logger.SetLevel(log.INFO)
+	return s
+}
+
+// Start starts ExtenderServer.
+func (s *ExtenderServer) Start(port int) (
+	func(), // function for shutdown
+	error,
+) {
+	e := s.e
+
+	go func() {
+		if err := e.Start(":" + strconv.Itoa(port)); err != nil && !xerrors.Is(err, http.ErrServerClosed) {
+			e.Logger.Fatalf("failed to start server successfully: %v", err)
+		}
+	}()
+	shutdownFn := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		if err := e.Shutdown(ctx); err != nil {
+			e.Logger.Warnf("failed to shutdown simulator server successfully: %v", err)
+		}
+	}
+
+	return shutdownFn, nil
+}

--- a/simulator/pkg/externalscheduler/external_scheduler.go
+++ b/simulator/pkg/externalscheduler/external_scheduler.go
@@ -26,83 +26,87 @@ import (
 	simulatorconfig "sigs.k8s.io/kube-scheduler-simulator/simulator/config"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler"
 	simulatorschedulerconfig "sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/config"
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/extender"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/plugin"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/storereflector"
 )
 
-// CreateOptionForOutOfTreePlugin creates the option which can be help with running the debuggable scheduler.
-// It does:
-// - create the wrapped plugin registries and return the registries as app.Option
-// - initialize and start the store reflector.
-// - the scheduler config conversion
-//   - reads the scheduling config passed from users (or use the default config)
-//   - converts it for enabling wrapped plugins
-//   - makes the defaulting func of the KubeSchedulerConfig always returning the converted one. We can let the scheduler use the converted configuration under any circumstances because the scheduler will always use this defaulting func to load the configuration.
+type Configs struct {
+	versioned   *v1.KubeSchedulerConfiguration
+	internalCfg *config.KubeSchedulerConfiguration
+	clientSet   *clientset.Clientset
+	sharedStore storereflector.Reflector
+	port        int
+}
+
+// NewConfigs loads flags and initializes kube scheduler configuration and clientSet.
+// It does the scheduler config conversion
+// - parse each flags.
+// - reads the scheduling config passed from users (or use the default config).
+// - converts it for enabling wrapped plugins.
+// - reads the kubeConfig and creates clientSet to enables storereflector to communicates with the api-server.
+// - initialize the store reflector.
 //
 // Deprecated: the externalscheduler package was renamed to the debuggablescheduler plugin. We'll remove it soon.
-//
-//nolint:funlen,cyclop
-func CreateOptionForOutOfTreePlugin(outOfTreePluginRegistry runtime.Registry, pluginExtender map[string]plugin.PluginExtenderInitializer) ([]app.Option, func(), error) {
-	if outOfTreePluginRegistry != nil {
-		simulatorschedulerconfig.SetOutOfTreeRegistries(outOfTreePluginRegistry)
-	}
-
+func NewConfigs() (Configs, error) {
 	// flags defined in the upstream scheduler
 	configFile := flag.String("config", "", "")
 	master := flag.String("master", "", "")
+	// port indicates port number of the proxy server for Extenders.
+	// This flag is debuggable_scheduler's own.
+	port := flag.Int("proxyPort", 1212, "")
 	flag.Parse()
 
-	var versionedcfg *v1.KubeSchedulerConfiguration
-	var err error
-	if configFile == nil {
-		versionedcfg, err = simulatorschedulerconfig.DefaultSchedulerConfig()
-		if err != nil {
-			return nil, nil, xerrors.Errorf("get default scheduler config: %w", err)
-		}
-	} else {
-		versionedcfg, err = loadConfigFromFile(*configFile)
-		if err != nil {
-			return nil, nil, xerrors.Errorf("load scheduler config: %w", err)
-		}
+	versionedcfg, err := loadKubeSchedulerConfig(configFile)
+	if err != nil {
+		return Configs{}, xerrors.Errorf("load scheduler config: %w", err)
 	}
 
 	versioned, err := scheduler.ConvertConfigurationForSimulator(versionedcfg)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("convert scheduler config to apply: %w", err)
+		return Configs{}, xerrors.Errorf("convert scheduler config to apply: %w", err)
 	}
 
 	internalCfg, err := scheduler.ConvertSchedulerConfigToInternalConfig(versioned)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("convert scheduler config to internal one: %w", err)
+		return Configs{}, xerrors.Errorf("convert scheduler config to internal one: %w", err)
 	}
 
-	sharedStore := storereflector.New()
+	clientSet, err := loadKubeConfig(master, internalCfg)
+	if err != nil {
+		return Configs{}, xerrors.Errorf("load kubeconfig: %w", err)
+	}
 
-	registry, err := plugin.NewRegistry(sharedStore, internalCfg, pluginExtender)
+	return Configs{
+		versioned:   versioned,
+		internalCfg: internalCfg,
+		clientSet:   clientSet,
+		sharedStore: storereflector.New(),
+		port:        *port,
+	}, nil
+}
+
+// CreateOptions creates the option which can be help with running the external scheduler
+// and resister the storereflector to informer.
+// Then, here makes the defaulting func of the KubeSchedulerConfig always returns the converted one.
+// We can let the scheduler use the converted configuration under any circumstances because the scheduler will always use this defaulting func to load the configuration.
+//
+// Deprecated: the externalscheduler package was renamed to the debuggablescheduler plugin. We'll remove it soon.
+func CreateOptions(configs Configs, outOfTreePluginRegistry runtime.Registry, pluginExtender map[string]plugin.PluginExtenderInitializer) ([]app.Option, func(), error) {
+	// Override the Extenders config so that the connection is directed to the simulator server.
+	extender.OverrideExtendersCfgToSimulator(configs.versioned, configs.port)
+
+	opts, err := CreateOptionForPlugin(outOfTreePluginRegistry, pluginExtender, configs.sharedStore, configs.internalCfg)
 	if err != nil {
-		return nil, nil, xerrors.Errorf("convert scheduler config to apply: %w", err)
-	}
-	kubeconfig, err := simulatorconfig.GetKubeClientConfig()
-	if err != nil {
-		return nil, nil, xerrors.Errorf("get kubeconfig: %w", err)
-	}
-	if internalCfg.ClientConnection.Kubeconfig != "" {
-		kubeconfig, err = createKubeConfig(internalCfg.ClientConnection, *master)
-		if err != nil {
-			return nil, nil, xerrors.Errorf("get kubeconfig specified in config: %w", err)
-		}
-	}
-	clientSet, err := clientset.NewForConfig(kubeconfig)
-	if err != nil {
-		return nil, nil, xerrors.Errorf("creates a new Clientset for kubeconfig: %w", err)
+		return nil, nil, xerrors.Errorf("CreateOptionForPlugin: %w", err)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	if err := sharedStore.ResisterResultSavingToInformer(clientSet, ctx.Done()); err != nil {
+	if err := configs.sharedStore.ResisterResultSavingToInformer(configs.clientSet, ctx.Done()); err != nil {
 		return nil, cancel, xerrors.Errorf("ResisterResultSavingToInformer of sharedStore: %w", err)
 	}
 
-	// black magic: We need to use the scheduler config converted for the simulator in the debuggable scheduler.
+	// black magic: We need to use the scheduler config converted for the simulator in the external scheduler.
 	// Here, we overwrite the defaulting func for KubeSchedulerConfiguration,
 	// so that user's config will be replaced with the one we created here
 	// when the scheduler loads the scheduler config
@@ -113,10 +117,30 @@ func CreateOptionForOutOfTreePlugin(outOfTreePluginRegistry runtime.Registry, pl
 			panic("unexpected type")
 		}
 		configv1.SetObjectDefaults_KubeSchedulerConfiguration(c)
-		c.Profiles = versioned.Profiles
+		c.Profiles = configs.versioned.Profiles
+		c.Extenders = configs.versioned.Extenders
 	})
 
-	return generateWithPluginOptions(registry), cancel, nil
+	return opts, cancel, nil
+}
+
+// CreateOptionForPlugin creates Option for in/out of tree plugins.
+// It does create the wrapped plugin registries and return the registries as app.Option.
+//
+// Deprecated: the externalscheduler package was renamed to the debuggablescheduler plugin. We'll remove it soon.
+func CreateOptionForPlugin(outOfTreePluginRegistry runtime.Registry, pluginExtender map[string]plugin.PluginExtenderInitializer, sharedStore storereflector.Reflector, internalCfg *config.KubeSchedulerConfiguration) ([]app.Option, error) {
+	if outOfTreePluginRegistry != nil {
+		// This must be called before plugin.NewRegistry().
+		simulatorschedulerconfig.SetOutOfTreeRegistries(outOfTreePluginRegistry)
+	}
+
+	// loads in/out of tree plugins and wraps it for debuggable.
+	registry, err := plugin.NewRegistry(sharedStore, internalCfg, pluginExtender)
+	if err != nil {
+		return nil, xerrors.Errorf("convert scheduler config to apply: %w", err)
+	}
+
+	return generateWithPluginOptions(registry), nil
 }
 
 // createKubeConfig creates a kubeConfig from the given config and masterOverride.
@@ -133,6 +157,43 @@ func createKubeConfig(config componentbaseconfig.ClientConnectionConfiguration, 
 	kubeConfig.Burst = int(config.Burst)
 
 	return kubeConfig, nil
+}
+
+// loadKubeSchedulerConfig loads specified scheduler config or default one.
+func loadKubeSchedulerConfig(configFile *string) (*v1.KubeSchedulerConfiguration, error) {
+	var versionedcfg *v1.KubeSchedulerConfiguration
+	var err error
+	if configFile == nil {
+		versionedcfg, err = simulatorschedulerconfig.DefaultSchedulerConfig()
+		if err != nil {
+			return nil, xerrors.Errorf("get default scheduler config: %w", err)
+		}
+	} else {
+		versionedcfg, err = loadConfigFromFile(*configFile)
+		if err != nil {
+			return nil, xerrors.Errorf("load scheduler config: %w", err)
+		}
+	}
+	return versionedcfg, nil
+}
+
+// loadKubeConfig loads kubeConfig.
+func loadKubeConfig(master *string, internalCfg *config.KubeSchedulerConfiguration) (*clientset.Clientset, error) {
+	kubeconfig, err := simulatorconfig.GetKubeClientConfig()
+	if err != nil {
+		return nil, xerrors.Errorf("get kubeconfig: %w", err)
+	}
+	if internalCfg.ClientConnection.Kubeconfig != "" {
+		kubeconfig, err = createKubeConfig(internalCfg.ClientConnection, *master)
+		if err != nil {
+			return nil, xerrors.Errorf("get kubeconfig specified in config: %w", err)
+		}
+	}
+	clientSet, err := clientset.NewForConfig(kubeconfig)
+	if err != nil {
+		return nil, xerrors.Errorf("creates a new Clientset for kubeconfig: %w", err)
+	}
+	return clientSet, nil
 }
 
 func generateWithPluginOptions(registry map[string]runtime.PluginFactory) []app.Option {

--- a/simulator/scheduler/scheduler.go
+++ b/simulator/scheduler/scheduler.go
@@ -116,7 +116,7 @@ func (s *Service) StartScheduler(versionedcfg *configv1.KubeSchedulerConfigurati
 	s.currentSchedulerCfg = versionedcfg.DeepCopy()
 
 	var err error
-	// Extender service must be initialized using unconverted config.
+	// Extender service must be initialized using `versionedcfg.Extenders` config which is not override for simulator (before calling OverrideExtendersCfgToSimulator()).
 	s.extenderService, err = extender.New(clientSet, versionedcfg.Extenders, s.sharedStore)
 	if err != nil {
 		return xerrors.Errorf("New extender service: %w", err)

--- a/simulator/server/server.go
+++ b/simulator/server/server.go
@@ -51,10 +51,7 @@ func NewSimulatorServer(cfg *config.Config, dic *di.Container) *SimulatorServer 
 
 	v1.GET("/listwatchresources", resourcewatcherHandler.ListWatchResources)
 
-	v1.POST("/extender/filter/:id", extenderHandler.Filter)
-	v1.POST("/extender/prioritize/:id", extenderHandler.Prioritize)
-	v1.POST("/extender/preempt/:id", extenderHandler.Preempt)
-	v1.POST("/extender/bind/:id", extenderHandler.Bind)
+	RouteExtender(v1, extenderHandler)
 
 	// initialize SimulatorServer.
 	s := &SimulatorServer{e: e}
@@ -85,4 +82,12 @@ func (s *SimulatorServer) Start(port int) (
 	}
 
 	return shutdownFn, nil
+}
+
+// RouteExtender routes request for extender to 4 endpoints.
+func RouteExtender(v1 *echo.Group, handler *handler.ExtenderHandler) {
+	v1.POST("/extender/filter/:id", handler.Filter)
+	v1.POST("/extender/prioritize/:id", handler.Prioritize)
+	v1.POST("/extender/preempt/:id", handler.Preempt)
+	v1.POST("/extender/bind/:id", handler.Bind)
 }

--- a/simulator/simulator.go
+++ b/simulator/simulator.go
@@ -91,11 +91,11 @@ func startSimulator() error {
 
 	// start simulator server
 	s := server.NewSimulatorServer(cfg, dic)
-	shutdownFn3, err := s.Start(cfg.Port)
+	shutdownFn, err := s.Start(cfg.Port)
 	if err != nil {
 		return xerrors.Errorf("start simulator server: %w", err)
 	}
-	defer shutdownFn3()
+	defer shutdownFn()
 
 	// wait the signal
 	quit := make(chan os.Signal, 1)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/area simulator
/kind feature
<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
TODO

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #291 

#### Results
Tested in my local.
```sh
$ k apply -f example3/configs/test-pod1.yaml
$  k describe pod annotation-second-scheduler
Name:             annotation-second-scheduler
Namespace:        default
Priority:         0
Service Account:  default
Node:             multinode-demo-m02/192.168.49.3
Start Time:       Mon, 14 Aug 2023 00:33:39 +0900
Labels:           name=multischeduler-example
Annotations:      noderesourcefit-prefilter-data: {"MilliCPU":0,"Memory":0,"EphemeralStorage":0,"AllowedPodNumber":0,"ScalarResources":null}
                  scheduler-simulator/bind-result: {"DefaultBinder":"success"}
                  scheduler-simulator/extender-bind-result: {}
                  scheduler-simulator/extender-filter-result:
                    {"http://localhost:8080/scheduler/":{"Nodes":{"metadata":{},"items":[{"metadata":{"name":"multinode-demo","uid":"c0a513f5-a00c-4eee-a72a-e...
                  scheduler-simulator/extender-preempt-result: {}
                  scheduler-simulator/extender-prioritize-result:
                    {"http://localhost:8080/scheduler/":[{"Host":"multinode-demo","Score":0},{"Host":"multinode-demo-m02","Score":0}]}
                  scheduler-simulator/filter-result:
                    {"multinode-demo":{"AzureDiskLimits":"passed","EBSLimits":"passed","GCEPDLimits":"passed","InterPodAffinity":"passed","NodeAffinity":"pass...
                  scheduler-simulator/finalscore-result:
                    {"multinode-demo":{"ImageLocality":"0","InterPodAffinity":"0","NodeAffinity":"0","NodeNumber":"0","NodeResourcesBalancedAllocation":"80","...
                  scheduler-simulator/permit-result: {}
                  scheduler-simulator/permit-result-timeout: {}
                  scheduler-simulator/postfilter-result: {}
                  scheduler-simulator/prebind-result: {"VolumeBinding":"success"}
                  scheduler-simulator/prefilter-result: {}
                  scheduler-simulator/prefilter-result-status:
                    {"InterPodAffinity":"success","NodeAffinity":"success","NodePorts":"success","NodeResourcesFit":"success","PodTopologySpread":"success","V...
                  scheduler-simulator/prescore-result:
                    {"InterPodAffinity":"success","NodeAffinity":"success","NodeNumber":"success","PodTopologySpread":"success","TaintToleration":"success"}
                  scheduler-simulator/reserve-result: {"VolumeBinding":"success"}
                  scheduler-simulator/result-history:
                    [{"noderesourcefit-prefilter-data":"{\"MilliCPU\":0,\"Memory\":0,\"EphemeralStorage\":0,\"AllowedPodNumber\":0,\"ScalarResources\":null}",...
                  scheduler-simulator/score-result:
                    {"multinode-demo":{"ImageLocality":"0","InterPodAffinity":"0","NodeAffinity":"0","NodeNumber":"0","NodeResourcesBalancedAllocation":"80","...
                  scheduler-simulator/selected-node: multinode-demo-m02
Status:           Running

```
(Formatted↓)
```sh
$ k get pod annotation-second-scheduler -o jsonpath='{.metadata.annotations}'
{
    "kubectl.kubernetes.io/last-applied-configuration": "{\"apiVersion\":\"v1\",\"kind\":\"Pod\",\"metadata\":{\"annotations\":{},\"labels\":{\"name\":\"multischeduler-example\"},\"name\":\"annotation-second-scheduler\",\"namespace\":\"default\"},\"spec\":{\"containers\":[{\"image\":\"registry.k8s.io/pause:2.0\",\"name\":\"pod-with-second-annotation-container\"}],\"schedulerName\":\"my-scheduler\"}}\n",
    "noderesourcefit-prefilter-data": "{\"MilliCPU\":0,\"Memory\":0,\"EphemeralStorage\":0,\"AllowedPodNumber\":0,\"ScalarResources\":null}",
    "scheduler-simulator/bind-result": "{\"DefaultBinder\":\"success\"}",
    "scheduler-simulator/extender-bind-result": "{}",
    "scheduler-simulator/extender-filter-result": "{\"http://localhost:8080/scheduler/\":{\"Nodes\":{\"metadata\":{},\"items\":[{\"metadata\":{\"name\":\"multinode-demo\",\"uid\":\"c0a513f5-a00c-4eee-a72a-e17cb9e53311\",\"resourceVersion\":\"181325\",\"creationTimestamp\":\"2023-06-29T17:05:51Z\",\"labels\":{\"beta.kubernetes.io/arch\":\"amd64\",\"beta.kubernetes.io/os\":\"linux\",\"kubernetes.io/arch\":\"amd64\",\"kubernetes.io/hostname\":\"multinode-demo\",\"kubernetes.io/os\":\"linux\",\"minikube.k8s.io/commit\":\"fe869b5d4da11ba318eb84a3ac00f336411de7ba\",\"minikube.k8s.io/name\":\"multinode-demo\",\"minikube.k8s.io/primary\":\"true\",\"minikube.k8s.io/updated_at\":\"2023_06_30T02_05_57_0700\",\"minikube.k8s.io/version\":\"v1.27.1\",\"node-role.kubernetes.io/control-plane\":\"\",\"node.kubernetes.io/exclude-from-external-load-balancers\":\"\"},\"annotations\":{\"kubeadm.alpha.kubernetes.io/cri-socket\":\"unix:///var/run/cri-dockerd.sock\",\"node.alpha.kubernetes.io/ttl\":\"0\",\"volumes.kubernetes.io/controller-managed-attach-detach\":\"true\"},\"managedFields\":[{\"manager\":\"kubelet\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-06-29T17:05:51Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:volumes.kubernetes.io/controller-managed-attach-detach\":{}},\"f:labels\":{\".\":{},\"f:beta.kubernetes.io/arch\":{},\"f:beta.kubernetes.io/os\":{},\"f:kubernetes.io/arch\":{},\"f:kubernetes.io/hostname\":{},\"f:kubernetes.io/os\":{}}}}},{\"manager\":\"kubeadm\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-06-29T17:05:54Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\"f:kubeadm.alpha.kubernetes.io/cri-socket\":{}},\"f:labels\":{\"f:node-role.kubernetes.io/control-plane\":{},\"f:node.kubernetes.io/exclude-from-external-load-balancers\":{}}}}},{\"manager\":\"kubectl-label\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-06-29T17:05:57Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:labels\":{\"f:minikube.k8s.io/commit\":{},\"f:minikube.k8s.io/name\":{},\"f:minikube.k8s.io/primary\":{},\"f:minikube.k8s.io/updated_at\":{},\"f:minikube.k8s.io/version\":{}}}}},{\"manager\":\"kube-controller-manager\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-07-31T13:02:21Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\"f:node.alpha.kubernetes.io/ttl\":{}}},\"f:spec\":{\"f:podCIDR\":{},\"f:podCIDRs\":{\".\":{},\"v:\\\"10.244.0.0/24\\\"\":{}}}}},{\"manager\":\"kubelet\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-08-13T15:31:31Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:status\":{\"f:conditions\":{\"k:{\\\"type\\\":\\\"DiskPressure\\\"}\":{\"f:lastHeartbeatTime\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:reason\":{},\"f:status\":{}},\"k:{\\\"type\\\":\\\"MemoryPressure\\\"}\":{\"f:lastHeartbeatTime\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:reason\":{},\"f:status\":{}},\"k:{\\\"type\\\":\\\"PIDPressure\\\"}\":{\"f:lastHeartbeatTime\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:reason\":{},\"f:status\":{}},\"k:{\\\"type\\\":\\\"Ready\\\"}\":{\"f:lastHeartbeatTime\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:reason\":{},\"f:status\":{}}},\"f:images\":{},\"f:nodeInfo\":{\"f:bootID\":{},\"f:containerRuntimeVersion\":{}}}}}]},\"spec\":{\"podCIDR\":\"10.244.0.0/24\",\"podCIDRs\":[\"10.244.0.0/24\"]},\"status\":{\"capacity\":{\"cpu\":\"2\",\"ephemeral-storage\":\"61202244Ki\",\"hugepages-1Gi\":\"0\",\"hugepages-2Mi\":\"0\",\"memory\":\"8048528Ki\",\"pods\":\"110\"},\"allocatable\":{\"cpu\":\"2\",\"ephemeral-storage\":\"61202244Ki\",\"hugepages-1Gi\":\"0\",\"hugepages-2Mi\":\"0\",\"memory\":\"8048528Ki\",\"pods\":\"110\"},\"conditions\":[{\"type\":\"MemoryPressure\",\"status\":\"False\",\"lastHeartbeatTime\":\"2023-08-13T15:31:31Z\",\"lastTransitionTime\":\"2023-07-31T09:01:33Z\",\"reason\":\"KubeletHasSufficientMemory\",\"message\":\"kubelet has sufficient memory available\"},{\"type\":\"DiskPressure\",\"status\":\"False\",\"lastHeartbeatTime\":\"2023-08-13T15:31:31Z\",\"lastTransitionTime\":\"2023-07-31T09:01:33Z\",\"reason\":\"KubeletHasNoDiskPressure\",\"message\":\"kubelet has no disk pressure\"},{\"type\":\"PIDPressure\",\"status\":\"False\",\"lastHeartbeatTime\":\"2023-08-13T15:31:31Z\",\"lastTransitionTime\":\"2023-07-31T09:01:33Z\",\"reason\":\"KubeletHasSufficientPID\",\"message\":\"kubelet has sufficient PID available\"},{\"type\":\"Ready\",\"status\":\"True\",\"lastHeartbeatTime\":\"2023-08-13T15:31:31Z\",\"lastTransitionTime\":\"2023-07-31T13:02:21Z\",\"reason\":\"KubeletReady\",\"message\":\"kubelet is posting ready status\"}],\"addresses\":[{\"type\":\"InternalIP\",\"address\":\"192.168.49.2\"},{\"type\":\"Hostname\",\"address\":\"multinode-demo\"}],\"daemonEndpoints\":{\"kubeletEndpoint\":{\"Port\":10250}},\"nodeInfo\":{\"machineID\":\"386775ffbc46464ea356d784cd8cd54c\",\"systemUUID\":\"e88c367f-68cc-496b-88a4-1eb5d87bdec3\",\"bootID\":\"ff3d334d-3586-41f2-a37f-4c2e4f8ae914\",\"kernelVersion\":\"5.15.49-linuxkit\",\"osImage\":\"Ubuntu 20.04.5 LTS\",\"containerRuntimeVersion\":\"docker://20.10.18\",\"kubeletVersion\":\"v1.25.2\",\"kubeProxyVersion\":\"v1.25.2\",\"operatingSystem\":\"linux\",\"architecture\":\"amd64\"},\"images\":[{\"names\":[\"registry.k8s.io/etcd@sha256:6f72b851544986cb0921b53ea655ec04c36131248f16d4ad110cb3ca0c369dc1\",\"registry.k8s.io/etcd:3.5.4-0\"],\"sizeBytes\":299520781},{\"names\":[\"registry.k8s.io/kube-apiserver@sha256:86e7b79379dddf58d7b7189d02ca96cc7e07d18efa4eb42adcaa4cf94531b96e\",\"registry.k8s.io/kube-apiserver:v1.25.2\"],\"sizeBytes\":127726803},{\"names\":[\"registry.k8s.io/kube-controller-manager@sha256:f961aee35fd2e9a5ee057365e56c5bf40a39bfef91f785f312e51891db41876b\",\"registry.k8s.io/kube-controller-manager:v1.25.2\"],\"sizeBytes\":117097964},{\"names\":[\"my-project/example-external-scheduler:1.0\"],\"sizeBytes\":83397345},{\"names\":[\"kindest/kindnetd@sha256:c19d6362a6a928139820761475a38c24c0cf84d507b9ddf414a078cf627497af\",\"kindest/kindnetd:v20230330-48f316cd\"],\"sizeBytes\":63267044},{\"names\":[\"kindest/kindnetd@sha256:273469d84ede51824194a31f6a405e3d3686b8b87cd161ea40f6bc3ff8e04ffe\",\"kindest/kindnetd:v20221004-44d545d1\"],\"sizeBytes\":61770893},{\"names\":[\"registry.k8s.io/kube-proxy@sha256:ddde7d23d168496d321ef9175a8bf964a54a982b026fb207c306d853cbbd4f77\",\"registry.k8s.io/kube-proxy:v1.25.2\"],\"sizeBytes\":61691938},{\"names\":[\"registry.k8s.io/kube-scheduler@sha256:ef2e24a920a7432aff5b435562301dde3beb528b0c7bbec58ddf0a9af64d5fce\",\"registry.k8s.io/kube-scheduler:v1.25.2\"],\"sizeBytes\":50583045},{\"names\":[\"registry.k8s.io/coredns/coredns@sha256:8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a\",\"registry.k8s.io/coredns/coredns:v1.9.3\"],\"sizeBytes\":48803555},{\"names\":[\"gcr.io/k8s-minikube/storage-provisioner@sha256:18eb69d1418e854ad5a19e399310e52808a8321e4c441c1dddad8977a0d7a944\",\"gcr.io/k8s-minikube/storage-provisioner:v5\"],\"sizeBytes\":31465472},{\"names\":[\"registry.k8s.io/pause@sha256:9001185023633d17a2f98ff69b6ff2615b8ea02a825adffa40422f51dfdcde9d\",\"registry.k8s.io/pause:3.8\"],\"sizeBytes\":711184},{\"names\":[\"k8s.gcr.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"k8s.gcr.io/pause:3.6\"],\"sizeBytes\":682696}]}},{\"metadata\":{\"name\":\"multinode-demo-m02\",\"uid\":\"7c686a06-f6ae-4e39-8b9f-e4d7c5777bb8\",\"resourceVersion\":\"181303\",\"creationTimestamp\":\"2023-08-13T09:29:31Z\",\"labels\":{\"beta.kubernetes.io/arch\":\"amd64\",\"beta.kubernetes.io/os\":\"linux\",\"kubernetes.io/arch\":\"amd64\",\"kubernetes.io/hostname\":\"multinode-demo-m02\",\"kubernetes.io/os\":\"linux\"},\"annotations\":{\"kubeadm.alpha.kubernetes.io/cri-socket\":\"/var/run/cri-dockerd.sock\",\"node.alpha.kubernetes.io/ttl\":\"0\",\"volumes.kubernetes.io/controller-managed-attach-detach\":\"true\"},\"managedFields\":[{\"manager\":\"kubeadm\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-08-13T09:29:31Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\"f:kubeadm.alpha.kubernetes.io/cri-socket\":{}}}}},{\"manager\":\"kubelet\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-08-13T09:29:31Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\".\":{},\"f:volumes.kubernetes.io/controller-managed-attach-detach\":{}},\"f:labels\":{\".\":{},\"f:beta.kubernetes.io/arch\":{},\"f:beta.kubernetes.io/os\":{},\"f:kubernetes.io/arch\":{},\"f:kubernetes.io/hostname\":{},\"f:kubernetes.io/os\":{}}}}},{\"manager\":\"kube-controller-manager\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-08-13T12:05:33Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:metadata\":{\"f:annotations\":{\"f:node.alpha.kubernetes.io/ttl\":{}}},\"f:spec\":{\"f:podCIDR\":{},\"f:podCIDRs\":{\".\":{},\"v:\\\"10.244.1.0/24\\\"\":{}}}}},{\"manager\":\"kubelet\",\"operation\":\"Update\",\"apiVersion\":\"v1\",\"time\":\"2023-08-13T15:30:22Z\",\"fieldsType\":\"FieldsV1\",\"fieldsV1\":{\"f:status\":{\"f:conditions\":{\"k:{\\\"type\\\":\\\"DiskPressure\\\"}\":{\"f:lastHeartbeatTime\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:reason\":{},\"f:status\":{}},\"k:{\\\"type\\\":\\\"MemoryPressure\\\"}\":{\"f:lastHeartbeatTime\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:reason\":{},\"f:status\":{}},\"k:{\\\"type\\\":\\\"PIDPressure\\\"}\":{\"f:lastHeartbeatTime\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:reason\":{},\"f:status\":{}},\"k:{\\\"type\\\":\\\"Ready\\\"}\":{\"f:lastHeartbeatTime\":{},\"f:lastTransitionTime\":{},\"f:message\":{},\"f:reason\":{},\"f:status\":{}}}}}}]},\"spec\":{\"podCIDR\":\"10.244.1.0/24\",\"podCIDRs\":[\"10.244.1.0/24\"]},\"status\":{\"capacity\":{\"cpu\":\"2\",\"ephemeral-storage\":\"61202244Ki\",\"hugepages-1Gi\":\"0\",\"hugepages-2Mi\":\"0\",\"memory\":\"8048528Ki\",\"pods\":\"110\"},\"allocatable\":{\"cpu\":\"2\",\"ephemeral-storage\":\"61202244Ki\",\"hugepages-1Gi\":\"0\",\"hugepages-2Mi\":\"0\",\"memory\":\"8048528Ki\",\"pods\":\"110\"},\"conditions\":[{\"type\":\"MemoryPressure\",\"status\":\"False\",\"lastHeartbeatTime\":\"2023-08-13T15:30:22Z\",\"lastTransitionTime\":\"2023-08-13T12:05:22Z\",\"reason\":\"KubeletHasSufficientMemory\",\"message\":\"kubelet has sufficient memory available\"},{\"type\":\"DiskPressure\",\"status\":\"False\",\"lastHeartbeatTime\":\"2023-08-13T15:30:22Z\",\"lastTransitionTime\":\"2023-08-13T12:05:22Z\",\"reason\":\"KubeletHasNoDiskPressure\",\"message\":\"kubelet has no disk pressure\"},{\"type\":\"PIDPressure\",\"status\":\"False\",\"lastHeartbeatTime\":\"2023-08-13T15:30:22Z\",\"lastTransitionTime\":\"2023-08-13T12:05:22Z\",\"reason\":\"KubeletHasSufficientPID\",\"message\":\"kubelet has sufficient PID available\"},{\"type\":\"Ready\",\"status\":\"True\",\"lastHeartbeatTime\":\"2023-08-13T15:30:22Z\",\"lastTransitionTime\":\"2023-08-13T12:05:33Z\",\"reason\":\"KubeletReady\",\"message\":\"kubelet is posting ready status\"}],\"addresses\":[{\"type\":\"InternalIP\",\"address\":\"192.168.49.3\"},{\"type\":\"Hostname\",\"address\":\"multinode-demo-m02\"}],\"daemonEndpoints\":{\"kubeletEndpoint\":{\"Port\":10250}},\"nodeInfo\":{\"machineID\":\"386775ffbc46464ea356d784cd8cd54c\",\"systemUUID\":\"82a4f625-c54f-4d13-89ad-3240b7a733df\",\"bootID\":\"ff3d334d-3586-41f2-a37f-4c2e4f8ae914\",\"kernelVersion\":\"5.15.49-linuxkit\",\"osImage\":\"Ubuntu 20.04.5 LTS\",\"containerRuntimeVersion\":\"docker://20.10.18\",\"kubeletVersion\":\"v1.25.2\",\"kubeProxyVersion\":\"v1.25.2\",\"operatingSystem\":\"linux\",\"architecture\":\"amd64\"},\"images\":[{\"names\":[\"registry.k8s.io/etcd@sha256:6f72b851544986cb0921b53ea655ec04c36131248f16d4ad110cb3ca0c369dc1\",\"registry.k8s.io/etcd:3.5.4-0\"],\"sizeBytes\":299520781},{\"names\":[\"registry.k8s.io/kube-apiserver@sha256:86e7b79379dddf58d7b7189d02ca96cc7e07d18efa4eb42adcaa4cf94531b96e\",\"registry.k8s.io/kube-apiserver:v1.25.2\"],\"sizeBytes\":127726803},{\"names\":[\"registry.k8s.io/kube-controller-manager@sha256:f961aee35fd2e9a5ee057365e56c5bf40a39bfef91f785f312e51891db41876b\",\"registry.k8s.io/kube-controller-manager:v1.25.2\"],\"sizeBytes\":117097964},{\"names\":[\"my-project/example-external-scheduler:1.0\"],\"sizeBytes\":83397345},{\"names\":[\"kindest/kindnetd@sha256:c19d6362a6a928139820761475a38c24c0cf84d507b9ddf414a078cf627497af\",\"kindest/kindnetd:v20230330-48f316cd\"],\"sizeBytes\":63267044},{\"names\":[\"kindest/kindnetd@sha256:273469d84ede51824194a31f6a405e3d3686b8b87cd161ea40f6bc3ff8e04ffe\",\"kindest/kindnetd:v20221004-44d545d1\"],\"sizeBytes\":61770893},{\"names\":[\"registry.k8s.io/kube-proxy@sha256:ddde7d23d168496d321ef9175a8bf964a54a982b026fb207c306d853cbbd4f77\",\"registry.k8s.io/kube-proxy:v1.25.2\"],\"sizeBytes\":61691938},{\"names\":[\"registry.k8s.io/kube-scheduler@sha256:ef2e24a920a7432aff5b435562301dde3beb528b0c7bbec58ddf0a9af64d5fce\",\"registry.k8s.io/kube-scheduler:v1.25.2\"],\"sizeBytes\":50583045},{\"names\":[\"registry.k8s.io/coredns/coredns@sha256:8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a\",\"registry.k8s.io/coredns/coredns:v1.9.3\"],\"sizeBytes\":48803555},{\"names\":[\"gcr.io/k8s-minikube/storage-provisioner@sha256:18eb69d1418e854ad5a19e399310e52808a8321e4c441c1dddad8977a0d7a944\",\"gcr.io/k8s-minikube/storage-provisioner:v5\"],\"sizeBytes\":31465472},{\"names\":[\"registry.k8s.io/pause@sha256:9001185023633d17a2f98ff69b6ff2615b8ea02a825adffa40422f51dfdcde9d\",\"registry.k8s.io/pause:3.8\"],\"sizeBytes\":711184},{\"names\":[\"k8s.gcr.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"k8s.gcr.io/pause:3.6\"],\"sizeBytes\":682696},{\"names\":[\"registry.k8s.io/pause@sha256:9ce5316f9752b8347484ab0f6778573af15524124d52b93230b9a0dcc987e73e\",\"registry.k8s.io/pause:2.0\"],\"sizeBytes\":350164}]}}]},\"NodeNames\":null,\"FailedNodes\":{},\"FailedAndUnresolvableNodes\":null,\"Error\":\"\"}}",
    "scheduler-simulator/extender-preempt-result": "{}",
    "scheduler-simulator/extender-prioritize-result": "{\"http://localhost:8080/scheduler/\":[{\"Host\":\"multinode-demo\",\"Score\":0},{\"Host\":\"multinode-demo-m02\",\"Score\":0}]}",
    "scheduler-simulator/filter-result": "{\"multinode-demo\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"passed\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"},\"multinode-demo-m02\":{\"AzureDiskLimits\":\"passed\",\"EBSLimits\":\"passed\",\"GCEPDLimits\":\"passed\",\"InterPodAffinity\":\"passed\",\"NodeAffinity\":\"passed\",\"NodeName\":\"passed\",\"NodePorts\":\"passed\",\"NodeResourcesFit\":\"passed\",\"NodeUnschedulable\":\"passed\",\"NodeVolumeLimits\":\"passed\",\"PodTopologySpread\":\"passed\",\"TaintToleration\":\"passed\",\"VolumeBinding\":\"passed\",\"VolumeRestrictions\":\"passed\",\"VolumeZone\":\"passed\"}}",
    "scheduler-simulator/finalscore-result": "{\"multinode-demo\":{\"ImageLocality\":\"0\",\"InterPodAffinity\":\"0\",\"NodeAffinity\":\"0\",\"NodeNumber\":\"0\",\"NodeResourcesBalancedAllocation\":\"80\",\"NodeResourcesFit\":\"65\",\"PodTopologySpread\":\"200\",\"TaintToleration\":\"300\",\"VolumeBinding\":\"0\"},\"multinode-demo-m02\":{\"ImageLocality\":\"0\",\"InterPodAffinity\":\"0\",\"NodeAffinity\":\"0\",\"NodeNumber\":\"0\",\"NodeResourcesBalancedAllocation\":\"97\",\"NodeResourcesFit\":\"89\",\"PodTopologySpread\":\"200\",\"TaintToleration\":\"300\",\"VolumeBinding\":\"0\"}}",
    "scheduler-simulator/permit-result": "{}",
    "scheduler-simulator/permit-result-timeout": "{}",
    "scheduler-simulator/postfilter-result": "{}",
    "scheduler-simulator/prebind-result": "{\"VolumeBinding\":\"success\"}",
    "scheduler-simulator/prefilter-result": "{}",
    "scheduler-simulator/prefilter-result-status": "{\"InterPodAffinity\":\"success\",\"NodeAffinity\":\"success\",\"NodePorts\":\"success\",\"NodeResourcesFit\":\"success\",\"PodTopologySpread\":\"success\",\"VolumeBinding\":\"success\",\"VolumeRestrictions\":\"success\"}",
    "scheduler-simulator/prescore-result": "{\"InterPodAffinity\":\"success\",\"NodeAffinity\":\"success\",\"NodeNumber\":\"success\",\"PodTopologySpread\":\"success\",\"TaintToleration\":\"success\"}",
    "scheduler-simulator/reserve-result": "{\"VolumeBinding\":\"success\"}",
    "scheduler-simulator/result-history": "[{\"noderesourcefit-prefilter-data\":\"{\\\"MilliCPU\\\":0,\\\"Memory\\\":0,\\\"EphemeralStorage\\\":0,\\\"AllowedPodNumber\\\":0,\\\"ScalarResources\\\":null}\",\"scheduler-simulator/bind-result\":\"{\\\"DefaultBinder\\\":\\\"success\\\"}\",\"scheduler-simulator/extender-bind-result\":\"{}\",\"scheduler-simulator/extender-filter-result\":\"{\\\"http://localhost:8080/scheduler/\\\":{\\\"Nodes\\\":{\\\"metadata\\\":{},\\\"items\\\":[{\\\"metadata\\\":{\\\"name\\\":\\\"multinode-demo\\\",\\\"uid\\\":\\\"c0a513f5-a00c-4eee-a72a-e17cb9e53311\\\",\\\"resourceVersion\\\":\\\"181325\\\",\\\"creationTimestamp\\\":\\\"2023-06-29T17:05:51Z\\\",\\\"labels\\\":{\\\"beta.kubernetes.io/arch\\\":\\\"amd64\\\",\\\"beta.kubernetes.io/os\\\":\\\"linux\\\",\\\"kubernetes.io/arch\\\":\\\"amd64\\\",\\\"kubernetes.io/hostname\\\":\\\"multinode-demo\\\",\\\"kubernetes.io/os\\\":\\\"linux\\\",\\\"minikube.k8s.io/commit\\\":\\\"fe869b5d4da11ba318eb84a3ac00f336411de7ba\\\",\\\"minikube.k8s.io/name\\\":\\\"multinode-demo\\\",\\\"minikube.k8s.io/primary\\\":\\\"true\\\",\\\"minikube.k8s.io/updated_at\\\":\\\"2023_06_30T02_05_57_0700\\\",\\\"minikube.k8s.io/version\\\":\\\"v1.27.1\\\",\\\"node-role.kubernetes.io/control-plane\\\":\\\"\\\",\\\"node.kubernetes.io/exclude-from-external-load-balancers\\\":\\\"\\\"},\\\"annotations\\\":{\\\"kubeadm.alpha.kubernetes.io/cri-socket\\\":\\\"unix:///var/run/cri-dockerd.sock\\\",\\\"node.alpha.kubernetes.io/ttl\\\":\\\"0\\\",\\\"volumes.kubernetes.io/controller-managed-attach-detach\\\":\\\"true\\\"},\\\"managedFields\\\":[{\\\"manager\\\":\\\"kubelet\\\",\\\"operation\\\":\\\"Update\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"time\\\":\\\"2023-06-29T17:05:51Z\\\",\\\"fieldsType\\\":\\\"FieldsV1\\\",\\\"fieldsV1\\\":{\\\"f:metadata\\\":{\\\"f:annotations\\\":{\\\".\\\":{},\\\"f:volumes.kubernetes.io/controller-managed-attach-detach\\\":{}},\\\"f:labels\\\":{\\\".\\\":{},\\\"f:beta.kubernetes.io/arch\\\":{},\\\"f:beta.kubernetes.io/os\\\":{},\\\"f:kubernetes.io/arch\\\":{},\\\"f:kubernetes.io/hostname\\\":{},\\\"f:kubernetes.io/os\\\":{}}}}},{\\\"manager\\\":\\\"kubeadm\\\",\\\"operation\\\":\\\"Update\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"time\\\":\\\"2023-06-29T17:05:54Z\\\",\\\"fieldsType\\\":\\\"FieldsV1\\\",\\\"fieldsV1\\\":{\\\"f:metadata\\\":{\\\"f:annotations\\\":{\\\"f:kubeadm.alpha.kubernetes.io/cri-socket\\\":{}},\\\"f:labels\\\":{\\\"f:node-role.kubernetes.io/control-plane\\\":{},\\\"f:node.kubernetes.io/exclude-from-external-load-balancers\\\":{}}}}},{\\\"manager\\\":\\\"kubectl-label\\\",\\\"operation\\\":\\\"Update\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"time\\\":\\\"2023-06-29T17:05:57Z\\\",\\\"fieldsType\\\":\\\"FieldsV1\\\",\\\"fieldsV1\\\":{\\\"f:metadata\\\":{\\\"f:labels\\\":{\\\"f:minikube.k8s.io/commit\\\":{},\\\"f:minikube.k8s.io/name\\\":{},\\\"f:minikube.k8s.io/primary\\\":{},\\\"f:minikube.k8s.io/updated_at\\\":{},\\\"f:minikube.k8s.io/version\\\":{}}}}},{\\\"manager\\\":\\\"kube-controller-manager\\\",\\\"operation\\\":\\\"Update\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"time\\\":\\\"2023-07-31T13:02:21Z\\\",\\\"fieldsType\\\":\\\"FieldsV1\\\",\\\"fieldsV1\\\":{\\\"f:metadata\\\":{\\\"f:annotations\\\":{\\\"f:node.alpha.kubernetes.io/ttl\\\":{}}},\\\"f:spec\\\":{\\\"f:podCIDR\\\":{},\\\"f:podCIDRs\\\":{\\\".\\\":{},\\\"v:\\\\\\\"10.244.0.0/24\\\\\\\"\\\":{}}}}},{\\\"manager\\\":\\\"kubelet\\\",\\\"operation\\\":\\\"Update\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"time\\\":\\\"2023-08-13T15:31:31Z\\\",\\\"fieldsType\\\":\\\"FieldsV1\\\",\\\"fieldsV1\\\":{\\\"f:status\\\":{\\\"f:conditions\\\":{\\\"k:{\\\\\\\"type\\\\\\\":\\\\\\\"DiskPressure\\\\\\\"}\\\":{\\\"f:lastHeartbeatTime\\\":{},\\\"f:lastTransitionTime\\\":{},\\\"f:message\\\":{},\\\"f:reason\\\":{},\\\"f:status\\\":{}},\\\"k:{\\\\\\\"type\\\\\\\":\\\\\\\"MemoryPressure\\\\\\\"}\\\":{\\\"f:lastHeartbeatTime\\\":{},\\\"f:lastTransitionTime\\\":{},\\\"f:message\\\":{},\\\"f:reason\\\":{},\\\"f:status\\\":{}},\\\"k:{\\\\\\\"type\\\\\\\":\\\\\\\"PIDPressure\\\\\\\"}\\\":{\\\"f:lastHeartbeatTime\\\":{},\\\"f:lastTransitionTime\\\":{},\\\"f:message\\\":{},\\\"f:reason\\\":{},\\\"f:status\\\":{}},\\\"k:{\\\\\\\"type\\\\\\\":\\\\\\\"Ready\\\\\\\"}\\\":{\\\"f:lastHeartbeatTime\\\":{},\\\"f:lastTransitionTime\\\":{},\\\"f:message\\\":{},\\\"f:reason\\\":{},\\\"f:status\\\":{}}},\\\"f:images\\\":{},\\\"f:nodeInfo\\\":{\\\"f:bootID\\\":{},\\\"f:containerRuntimeVersion\\\":{}}}}}]},\\\"spec\\\":{\\\"podCIDR\\\":\\\"10.244.0.0/24\\\",\\\"podCIDRs\\\":[\\\"10.244.0.0/24\\\"]},\\\"status\\\":{\\\"capacity\\\":{\\\"cpu\\\":\\\"2\\\",\\\"ephemeral-storage\\\":\\\"61202244Ki\\\",\\\"hugepages-1Gi\\\":\\\"0\\\",\\\"hugepages-2Mi\\\":\\\"0\\\",\\\"memory\\\":\\\"8048528Ki\\\",\\\"pods\\\":\\\"110\\\"},\\\"allocatable\\\":{\\\"cpu\\\":\\\"2\\\",\\\"ephemeral-storage\\\":\\\"61202244Ki\\\",\\\"hugepages-1Gi\\\":\\\"0\\\",\\\"hugepages-2Mi\\\":\\\"0\\\",\\\"memory\\\":\\\"8048528Ki\\\",\\\"pods\\\":\\\"110\\\"},\\\"conditions\\\":[{\\\"type\\\":\\\"MemoryPressure\\\",\\\"status\\\":\\\"False\\\",\\\"lastHeartbeatTime\\\":\\\"2023-08-13T15:31:31Z\\\",\\\"lastTransitionTime\\\":\\\"2023-07-31T09:01:33Z\\\",\\\"reason\\\":\\\"KubeletHasSufficientMemory\\\",\\\"message\\\":\\\"kubelet has sufficient memory available\\\"},{\\\"type\\\":\\\"DiskPressure\\\",\\\"status\\\":\\\"False\\\",\\\"lastHeartbeatTime\\\":\\\"2023-08-13T15:31:31Z\\\",\\\"lastTransitionTime\\\":\\\"2023-07-31T09:01:33Z\\\",\\\"reason\\\":\\\"KubeletHasNoDiskPressure\\\",\\\"message\\\":\\\"kubelet has no disk pressure\\\"},{\\\"type\\\":\\\"PIDPressure\\\",\\\"status\\\":\\\"False\\\",\\\"lastHeartbeatTime\\\":\\\"2023-08-13T15:31:31Z\\\",\\\"lastTransitionTime\\\":\\\"2023-07-31T09:01:33Z\\\",\\\"reason\\\":\\\"KubeletHasSufficientPID\\\",\\\"message\\\":\\\"kubelet has sufficient PID available\\\"},{\\\"type\\\":\\\"Ready\\\",\\\"status\\\":\\\"True\\\",\\\"lastHeartbeatTime\\\":\\\"2023-08-13T15:31:31Z\\\",\\\"lastTransitionTime\\\":\\\"2023-07-31T13:02:21Z\\\",\\\"reason\\\":\\\"KubeletReady\\\",\\\"message\\\":\\\"kubelet is posting ready status\\\"}],\\\"addresses\\\":[{\\\"type\\\":\\\"InternalIP\\\",\\\"address\\\":\\\"192.168.49.2\\\"},{\\\"type\\\":\\\"Hostname\\\",\\\"address\\\":\\\"multinode-demo\\\"}],\\\"daemonEndpoints\\\":{\\\"kubeletEndpoint\\\":{\\\"Port\\\":10250}},\\\"nodeInfo\\\":{\\\"machineID\\\":\\\"386775ffbc46464ea356d784cd8cd54c\\\",\\\"systemUUID\\\":\\\"e88c367f-68cc-496b-88a4-1eb5d87bdec3\\\",\\\"bootID\\\":\\\"ff3d334d-3586-41f2-a37f-4c2e4f8ae914\\\",\\\"kernelVersion\\\":\\\"5.15.49-linuxkit\\\",\\\"osImage\\\":\\\"Ubuntu 20.04.5 LTS\\\",\\\"containerRuntimeVersion\\\":\\\"docker://20.10.18\\\",\\\"kubeletVersion\\\":\\\"v1.25.2\\\",\\\"kubeProxyVersion\\\":\\\"v1.25.2\\\",\\\"operatingSystem\\\":\\\"linux\\\",\\\"architecture\\\":\\\"amd64\\\"},\\\"images\\\":[{\\\"names\\\":[\\\"registry.k8s.io/etcd@sha256:6f72b851544986cb0921b53ea655ec04c36131248f16d4ad110cb3ca0c369dc1\\\",\\\"registry.k8s.io/etcd:3.5.4-0\\\"],\\\"sizeBytes\\\":299520781},{\\\"names\\\":[\\\"registry.k8s.io/kube-apiserver@sha256:86e7b79379dddf58d7b7189d02ca96cc7e07d18efa4eb42adcaa4cf94531b96e\\\",\\\"registry.k8s.io/kube-apiserver:v1.25.2\\\"],\\\"sizeBytes\\\":127726803},{\\\"names\\\":[\\\"registry.k8s.io/kube-controller-manager@sha256:f961aee35fd2e9a5ee057365e56c5bf40a39bfef91f785f312e51891db41876b\\\",\\\"registry.k8s.io/kube-controller-manager:v1.25.2\\\"],\\\"sizeBytes\\\":117097964},{\\\"names\\\":[\\\"my-project/example-external-scheduler:1.0\\\"],\\\"sizeBytes\\\":83397345},{\\\"names\\\":[\\\"kindest/kindnetd@sha256:c19d6362a6a928139820761475a38c24c0cf84d507b9ddf414a078cf627497af\\\",\\\"kindest/kindnetd:v20230330-48f316cd\\\"],\\\"sizeBytes\\\":63267044},{\\\"names\\\":[\\\"kindest/kindnetd@sha256:273469d84ede51824194a31f6a405e3d3686b8b87cd161ea40f6bc3ff8e04ffe\\\",\\\"kindest/kindnetd:v20221004-44d545d1\\\"],\\\"sizeBytes\\\":61770893},{\\\"names\\\":[\\\"registry.k8s.io/kube-proxy@sha256:ddde7d23d168496d321ef9175a8bf964a54a982b026fb207c306d853cbbd4f77\\\",\\\"registry.k8s.io/kube-proxy:v1.25.2\\\"],\\\"sizeBytes\\\":61691938},{\\\"names\\\":[\\\"registry.k8s.io/kube-scheduler@sha256:ef2e24a920a7432aff5b435562301dde3beb528b0c7bbec58ddf0a9af64d5fce\\\",\\\"registry.k8s.io/kube-scheduler:v1.25.2\\\"],\\\"sizeBytes\\\":50583045},{\\\"names\\\":[\\\"registry.k8s.io/coredns/coredns@sha256:8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a\\\",\\\"registry.k8s.io/coredns/coredns:v1.9.3\\\"],\\\"sizeBytes\\\":48803555},{\\\"names\\\":[\\\"gcr.io/k8s-minikube/storage-provisioner@sha256:18eb69d1418e854ad5a19e399310e52808a8321e4c441c1dddad8977a0d7a944\\\",\\\"gcr.io/k8s-minikube/storage-provisioner:v5\\\"],\\\"sizeBytes\\\":31465472},{\\\"names\\\":[\\\"registry.k8s.io/pause@sha256:9001185023633d17a2f98ff69b6ff2615b8ea02a825adffa40422f51dfdcde9d\\\",\\\"registry.k8s.io/pause:3.8\\\"],\\\"sizeBytes\\\":711184},{\\\"names\\\":[\\\"k8s.gcr.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\\\",\\\"k8s.gcr.io/pause:3.6\\\"],\\\"sizeBytes\\\":682696}]}},{\\\"metadata\\\":{\\\"name\\\":\\\"multinode-demo-m02\\\",\\\"uid\\\":\\\"7c686a06-f6ae-4e39-8b9f-e4d7c5777bb8\\\",\\\"resourceVersion\\\":\\\"181303\\\",\\\"creationTimestamp\\\":\\\"2023-08-13T09:29:31Z\\\",\\\"labels\\\":{\\\"beta.kubernetes.io/arch\\\":\\\"amd64\\\",\\\"beta.kubernetes.io/os\\\":\\\"linux\\\",\\\"kubernetes.io/arch\\\":\\\"amd64\\\",\\\"kubernetes.io/hostname\\\":\\\"multinode-demo-m02\\\",\\\"kubernetes.io/os\\\":\\\"linux\\\"},\\\"annotations\\\":{\\\"kubeadm.alpha.kubernetes.io/cri-socket\\\":\\\"/var/run/cri-dockerd.sock\\\",\\\"node.alpha.kubernetes.io/ttl\\\":\\\"0\\\",\\\"volumes.kubernetes.io/controller-managed-attach-detach\\\":\\\"true\\\"},\\\"managedFields\\\":[{\\\"manager\\\":\\\"kubeadm\\\",\\\"operation\\\":\\\"Update\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"time\\\":\\\"2023-08-13T09:29:31Z\\\",\\\"fieldsType\\\":\\\"FieldsV1\\\",\\\"fieldsV1\\\":{\\\"f:metadata\\\":{\\\"f:annotations\\\":{\\\"f:kubeadm.alpha.kubernetes.io/cri-socket\\\":{}}}}},{\\\"manager\\\":\\\"kubelet\\\",\\\"operation\\\":\\\"Update\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"time\\\":\\\"2023-08-13T09:29:31Z\\\",\\\"fieldsType\\\":\\\"FieldsV1\\\",\\\"fieldsV1\\\":{\\\"f:metadata\\\":{\\\"f:annotations\\\":{\\\".\\\":{},\\\"f:volumes.kubernetes.io/controller-managed-attach-detach\\\":{}},\\\"f:labels\\\":{\\\".\\\":{},\\\"f:beta.kubernetes.io/arch\\\":{},\\\"f:beta.kubernetes.io/os\\\":{},\\\"f:kubernetes.io/arch\\\":{},\\\"f:kubernetes.io/hostname\\\":{},\\\"f:kubernetes.io/os\\\":{}}}}},{\\\"manager\\\":\\\"kube-controller-manager\\\",\\\"operation\\\":\\\"Update\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"time\\\":\\\"2023-08-13T12:05:33Z\\\",\\\"fieldsType\\\":\\\"FieldsV1\\\",\\\"fieldsV1\\\":{\\\"f:metadata\\\":{\\\"f:annotations\\\":{\\\"f:node.alpha.kubernetes.io/ttl\\\":{}}},\\\"f:spec\\\":{\\\"f:podCIDR\\\":{},\\\"f:podCIDRs\\\":{\\\".\\\":{},\\\"v:\\\\\\\"10.244.1.0/24\\\\\\\"\\\":{}}}}},{\\\"manager\\\":\\\"kubelet\\\",\\\"operation\\\":\\\"Update\\\",\\\"apiVersion\\\":\\\"v1\\\",\\\"time\\\":\\\"2023-08-13T15:30:22Z\\\",\\\"fieldsType\\\":\\\"FieldsV1\\\",\\\"fieldsV1\\\":{\\\"f:status\\\":{\\\"f:conditions\\\":{\\\"k:{\\\\\\\"type\\\\\\\":\\\\\\\"DiskPressure\\\\\\\"}\\\":{\\\"f:lastHeartbeatTime\\\":{},\\\"f:lastTransitionTime\\\":{},\\\"f:message\\\":{},\\\"f:reason\\\":{},\\\"f:status\\\":{}},\\\"k:{\\\\\\\"type\\\\\\\":\\\\\\\"MemoryPressure\\\\\\\"}\\\":{\\\"f:lastHeartbeatTime\\\":{},\\\"f:lastTransitionTime\\\":{},\\\"f:message\\\":{},\\\"f:reason\\\":{},\\\"f:status\\\":{}},\\\"k:{\\\\\\\"type\\\\\\\":\\\\\\\"PIDPressure\\\\\\\"}\\\":{\\\"f:lastHeartbeatTime\\\":{},\\\"f:lastTransitionTime\\\":{},\\\"f:message\\\":{},\\\"f:reason\\\":{},\\\"f:status\\\":{}},\\\"k:{\\\\\\\"type\\\\\\\":\\\\\\\"Ready\\\\\\\"}\\\":{\\\"f:lastHeartbeatTime\\\":{},\\\"f:lastTransitionTime\\\":{},\\\"f:message\\\":{},\\\"f:reason\\\":{},\\\"f:status\\\":{}}}}}}]},\\\"spec\\\":{\\\"podCIDR\\\":\\\"10.244.1.0/24\\\",\\\"podCIDRs\\\":[\\\"10.244.1.0/24\\\"]},\\\"status\\\":{\\\"capacity\\\":{\\\"cpu\\\":\\\"2\\\",\\\"ephemeral-storage\\\":\\\"61202244Ki\\\",\\\"hugepages-1Gi\\\":\\\"0\\\",\\\"hugepages-2Mi\\\":\\\"0\\\",\\\"memory\\\":\\\"8048528Ki\\\",\\\"pods\\\":\\\"110\\\"},\\\"allocatable\\\":{\\\"cpu\\\":\\\"2\\\",\\\"ephemeral-storage\\\":\\\"61202244Ki\\\",\\\"hugepages-1Gi\\\":\\\"0\\\",\\\"hugepages-2Mi\\\":\\\"0\\\",\\\"memory\\\":\\\"8048528Ki\\\",\\\"pods\\\":\\\"110\\\"},\\\"conditions\\\":[{\\\"type\\\":\\\"MemoryPressure\\\",\\\"status\\\":\\\"False\\\",\\\"lastHeartbeatTime\\\":\\\"2023-08-13T15:30:22Z\\\",\\\"lastTransitionTime\\\":\\\"2023-08-13T12:05:22Z\\\",\\\"reason\\\":\\\"KubeletHasSufficientMemory\\\",\\\"message\\\":\\\"kubelet has sufficient memory available\\\"},{\\\"type\\\":\\\"DiskPressure\\\",\\\"status\\\":\\\"False\\\",\\\"lastHeartbeatTime\\\":\\\"2023-08-13T15:30:22Z\\\",\\\"lastTransitionTime\\\":\\\"2023-08-13T12:05:22Z\\\",\\\"reason\\\":\\\"KubeletHasNoDiskPressure\\\",\\\"message\\\":\\\"kubelet has no disk pressure\\\"},{\\\"type\\\":\\\"PIDPressure\\\",\\\"status\\\":\\\"False\\\",\\\"lastHeartbeatTime\\\":\\\"2023-08-13T15:30:22Z\\\",\\\"lastTransitionTime\\\":\\\"2023-08-13T12:05:22Z\\\",\\\"reason\\\":\\\"KubeletHasSufficientPID\\\",\\\"message\\\":\\\"kubelet has sufficient PID available\\\"},{\\\"type\\\":\\\"Ready\\\",\\\"status\\\":\\\"True\\\",\\\"lastHeartbeatTime\\\":\\\"2023-08-13T15:30:22Z\\\",\\\"lastTransitionTime\\\":\\\"2023-08-13T12:05:33Z\\\",\\\"reason\\\":\\\"KubeletReady\\\",\\\"message\\\":\\\"kubelet is posting ready status\\\"}],\\\"addresses\\\":[{\\\"type\\\":\\\"InternalIP\\\",\\\"address\\\":\\\"192.168.49.3\\\"},{\\\"type\\\":\\\"Hostname\\\",\\\"address\\\":\\\"multinode-demo-m02\\\"}],\\\"daemonEndpoints\\\":{\\\"kubeletEndpoint\\\":{\\\"Port\\\":10250}},\\\"nodeInfo\\\":{\\\"machineID\\\":\\\"386775ffbc46464ea356d784cd8cd54c\\\",\\\"systemUUID\\\":\\\"82a4f625-c54f-4d13-89ad-3240b7a733df\\\",\\\"bootID\\\":\\\"ff3d334d-3586-41f2-a37f-4c2e4f8ae914\\\",\\\"kernelVersion\\\":\\\"5.15.49-linuxkit\\\",\\\"osImage\\\":\\\"Ubuntu 20.04.5 LTS\\\",\\\"containerRuntimeVersion\\\":\\\"docker://20.10.18\\\",\\\"kubeletVersion\\\":\\\"v1.25.2\\\",\\\"kubeProxyVersion\\\":\\\"v1.25.2\\\",\\\"operatingSystem\\\":\\\"linux\\\",\\\"architecture\\\":\\\"amd64\\\"},\\\"images\\\":[{\\\"names\\\":[\\\"registry.k8s.io/etcd@sha256:6f72b851544986cb0921b53ea655ec04c36131248f16d4ad110cb3ca0c369dc1\\\",\\\"registry.k8s.io/etcd:3.5.4-0\\\"],\\\"sizeBytes\\\":299520781},{\\\"names\\\":[\\\"registry.k8s.io/kube-apiserver@sha256:86e7b79379dddf58d7b7189d02ca96cc7e07d18efa4eb42adcaa4cf94531b96e\\\",\\\"registry.k8s.io/kube-apiserver:v1.25.2\\\"],\\\"sizeBytes\\\":127726803},{\\\"names\\\":[\\\"registry.k8s.io/kube-controller-manager@sha256:f961aee35fd2e9a5ee057365e56c5bf40a39bfef91f785f312e51891db41876b\\\",\\\"registry.k8s.io/kube-controller-manager:v1.25.2\\\"],\\\"sizeBytes\\\":117097964},{\\\"names\\\":[\\\"my-project/example-external-scheduler:1.0\\\"],\\\"sizeBytes\\\":83397345},{\\\"names\\\":[\\\"kindest/kindnetd@sha256:c19d6362a6a928139820761475a38c24c0cf84d507b9ddf414a078cf627497af\\\",\\\"kindest/kindnetd:v20230330-48f316cd\\\"],\\\"sizeBytes\\\":63267044},{\\\"names\\\":[\\\"kindest/kindnetd@sha256:273469d84ede51824194a31f6a405e3d3686b8b87cd161ea40f6bc3ff8e04ffe\\\",\\\"kindest/kindnetd:v20221004-44d545d1\\\"],\\\"sizeBytes\\\":61770893},{\\\"names\\\":[\\\"registry.k8s.io/kube-proxy@sha256:ddde7d23d168496d321ef9175a8bf964a54a982b026fb207c306d853cbbd4f77\\\",\\\"registry.k8s.io/kube-proxy:v1.25.2\\\"],\\\"sizeBytes\\\":61691938},{\\\"names\\\":[\\\"registry.k8s.io/kube-scheduler@sha256:ef2e24a920a7432aff5b435562301dde3beb528b0c7bbec58ddf0a9af64d5fce\\\",\\\"registry.k8s.io/kube-scheduler:v1.25.2\\\"],\\\"sizeBytes\\\":50583045},{\\\"names\\\":[\\\"registry.k8s.io/coredns/coredns@sha256:8e352a029d304ca7431c6507b56800636c321cb52289686a581ab70aaa8a2e2a\\\",\\\"registry.k8s.io/coredns/coredns:v1.9.3\\\"],\\\"sizeBytes\\\":48803555},{\\\"names\\\":[\\\"gcr.io/k8s-minikube/storage-provisioner@sha256:18eb69d1418e854ad5a19e399310e52808a8321e4c441c1dddad8977a0d7a944\\\",\\\"gcr.io/k8s-minikube/storage-provisioner:v5\\\"],\\\"sizeBytes\\\":31465472},{\\\"names\\\":[\\\"registry.k8s.io/pause@sha256:9001185023633d17a2f98ff69b6ff2615b8ea02a825adffa40422f51dfdcde9d\\\",\\\"registry.k8s.io/pause:3.8\\\"],\\\"sizeBytes\\\":711184},{\\\"names\\\":[\\\"k8s.gcr.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\\\",\\\"k8s.gcr.io/pause:3.6\\\"],\\\"sizeBytes\\\":682696},{\\\"names\\\":[\\\"registry.k8s.io/pause@sha256:9ce5316f9752b8347484ab0f6778573af15524124d52b93230b9a0dcc987e73e\\\",\\\"registry.k8s.io/pause:2.0\\\"],\\\"sizeBytes\\\":350164}]}}]},\\\"NodeNames\\\":null,\\\"FailedNodes\\\":{},\\\"FailedAndUnresolvableNodes\\\":null,\\\"Error\\\":\\\"\\\"}}\",\"scheduler-simulator/extender-preempt-result\":\"{}\",\"scheduler-simulator/extender-prioritize-result\":\"{\\\"http://localhost:8080/scheduler/\\\":[{\\\"Host\\\":\\\"multinode-demo\\\",\\\"Score\\\":0},{\\\"Host\\\":\\\"multinode-demo-m02\\\",\\\"Score\\\":0}]}\",\"scheduler-simulator/filter-result\":\"{\\\"multinode-demo\\\":{\\\"AzureDiskLimits\\\":\\\"passed\\\",\\\"EBSLimits\\\":\\\"passed\\\",\\\"GCEPDLimits\\\":\\\"passed\\\",\\\"InterPodAffinity\\\":\\\"passed\\\",\\\"NodeAffinity\\\":\\\"passed\\\",\\\"NodeName\\\":\\\"passed\\\",\\\"NodePorts\\\":\\\"passed\\\",\\\"NodeResourcesFit\\\":\\\"passed\\\",\\\"NodeUnschedulable\\\":\\\"passed\\\",\\\"NodeVolumeLimits\\\":\\\"passed\\\",\\\"PodTopologySpread\\\":\\\"passed\\\",\\\"TaintToleration\\\":\\\"passed\\\",\\\"VolumeBinding\\\":\\\"passed\\\",\\\"VolumeRestrictions\\\":\\\"passed\\\",\\\"VolumeZone\\\":\\\"passed\\\"},\\\"multinode-demo-m02\\\":{\\\"AzureDiskLimits\\\":\\\"passed\\\",\\\"EBSLimits\\\":\\\"passed\\\",\\\"GCEPDLimits\\\":\\\"passed\\\",\\\"InterPodAffinity\\\":\\\"passed\\\",\\\"NodeAffinity\\\":\\\"passed\\\",\\\"NodeName\\\":\\\"passed\\\",\\\"NodePorts\\\":\\\"passed\\\",\\\"NodeResourcesFit\\\":\\\"passed\\\",\\\"NodeUnschedulable\\\":\\\"passed\\\",\\\"NodeVolumeLimits\\\":\\\"passed\\\",\\\"PodTopologySpread\\\":\\\"passed\\\",\\\"TaintToleration\\\":\\\"passed\\\",\\\"VolumeBinding\\\":\\\"passed\\\",\\\"VolumeRestrictions\\\":\\\"passed\\\",\\\"VolumeZone\\\":\\\"passed\\\"}}\",\"scheduler-simulator/finalscore-result\":\"{\\\"multinode-demo\\\":{\\\"ImageLocality\\\":\\\"0\\\",\\\"InterPodAffinity\\\":\\\"0\\\",\\\"NodeAffinity\\\":\\\"0\\\",\\\"NodeNumber\\\":\\\"0\\\",\\\"NodeResourcesBalancedAllocation\\\":\\\"80\\\",\\\"NodeResourcesFit\\\":\\\"65\\\",\\\"PodTopologySpread\\\":\\\"200\\\",\\\"TaintToleration\\\":\\\"300\\\",\\\"VolumeBinding\\\":\\\"0\\\"},\\\"multinode-demo-m02\\\":{\\\"ImageLocality\\\":\\\"0\\\",\\\"InterPodAffinity\\\":\\\"0\\\",\\\"NodeAffinity\\\":\\\"0\\\",\\\"NodeNumber\\\":\\\"0\\\",\\\"NodeResourcesBalancedAllocation\\\":\\\"97\\\",\\\"NodeResourcesFit\\\":\\\"89\\\",\\\"PodTopologySpread\\\":\\\"200\\\",\\\"TaintToleration\\\":\\\"300\\\",\\\"VolumeBinding\\\":\\\"0\\\"}}\",\"scheduler-simulator/permit-result\":\"{}\",\"scheduler-simulator/permit-result-timeout\":\"{}\",\"scheduler-simulator/postfilter-result\":\"{}\",\"scheduler-simulator/prebind-result\":\"{\\\"VolumeBinding\\\":\\\"success\\\"}\",\"scheduler-simulator/prefilter-result\":\"{}\",\"scheduler-simulator/prefilter-result-status\":\"{\\\"InterPodAffinity\\\":\\\"success\\\",\\\"NodeAffinity\\\":\\\"success\\\",\\\"NodePorts\\\":\\\"success\\\",\\\"NodeResourcesFit\\\":\\\"success\\\",\\\"PodTopologySpread\\\":\\\"success\\\",\\\"VolumeBinding\\\":\\\"success\\\",\\\"VolumeRestrictions\\\":\\\"success\\\"}\",\"scheduler-simulator/prescore-result\":\"{\\\"InterPodAffinity\\\":\\\"success\\\",\\\"NodeAffinity\\\":\\\"success\\\",\\\"NodeNumber\\\":\\\"success\\\",\\\"PodTopologySpread\\\":\\\"success\\\",\\\"TaintToleration\\\":\\\"success\\\"}\",\"scheduler-simulator/reserve-result\":\"{\\\"VolumeBinding\\\":\\\"success\\\"}\",\"scheduler-simulator/score-result\":\"{\\\"multinode-demo\\\":{\\\"ImageLocality\\\":\\\"0\\\",\\\"InterPodAffinity\\\":\\\"0\\\",\\\"NodeAffinity\\\":\\\"0\\\",\\\"NodeNumber\\\":\\\"0\\\",\\\"NodeResourcesBalancedAllocation\\\":\\\"80\\\",\\\"NodeResourcesFit\\\":\\\"65\\\",\\\"PodTopologySpread\\\":\\\"0\\\",\\\"TaintToleration\\\":\\\"0\\\",\\\"VolumeBinding\\\":\\\"0\\\"},\\\"multinode-demo-m02\\\":{\\\"ImageLocality\\\":\\\"0\\\",\\\"InterPodAffinity\\\":\\\"0\\\",\\\"NodeAffinity\\\":\\\"0\\\",\\\"NodeNumber\\\":\\\"0\\\",\\\"NodeResourcesBalancedAllocation\\\":\\\"97\\\",\\\"NodeResourcesFit\\\":\\\"89\\\",\\\"PodTopologySpread\\\":\\\"0\\\",\\\"TaintToleration\\\":\\\"0\\\",\\\"VolumeBinding\\\":\\\"0\\\"}}\",\"scheduler-simulator/selected-node\":\"multinode-demo-m02\"}]",
    "scheduler-simulator/score-result": "{\"multinode-demo\":{\"ImageLocality\":\"0\",\"InterPodAffinity\":\"0\",\"NodeAffinity\":\"0\",\"NodeNumber\":\"0\",\"NodeResourcesBalancedAllocation\":\"80\",\"NodeResourcesFit\":\"65\",\"PodTopologySpread\":\"0\",\"TaintToleration\":\"0\",\"VolumeBinding\":\"0\"},\"multinode-demo-m02\":{\"ImageLocality\":\"0\",\"InterPodAffinity\":\"0\",\"NodeAffinity\":\"0\",\"NodeNumber\":\"0\",\"NodeResourcesBalancedAllocation\":\"97\",\"NodeResourcesFit\":\"89\",\"PodTopologySpread\":\"0\",\"TaintToleration\":\"0\",\"VolumeBinding\":\"0\"}}",
    "scheduler-simulator/selected-node": "multinode-demo-m02"
}
```
#### Special notes for your reviewer:

In order to resolve issue 318 in the near future, I'd like to split the `CreateOptionForOutOfTreePlugin()` process by purpose.


/assign @sanposhiho 

/label tide/merge-method-squash
