### PR TITLE
fix: reduce the places where users have to register for using custom plugins

### DIFF
--- a/simulator/docs/custom-plugin.md
+++ b/simulator/docs/custom-plugin.md
@@ -19,7 +19,7 @@ by passing a default KubeSchedulerConfiguration file via the environment variabl
 
 ### Example
 
-We will explain the case where you want to add [nodenumber](../sample/nodenumber/plugin.go) plugin as example.
+We will explain the case where you want to add [nodenumber](./sample/nodenumber/plugin.go) plugin as example.
 
 The nodenumber plugin is an example plugin that favors nodes that have the number suffix which is the same as the number suffix of the pod name.
 And we can configure it via `NodeNumberArgs`.

--- a/simulator/scheduler/config/plugin.go
+++ b/simulator/scheduler/config/plugin.go
@@ -7,13 +7,9 @@ import (
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
 )
 
-var (
-	outOfTreeRegistries = runtime.Registry{
-		// TODO(user): add your plugins registries here.
-	}
-
-	registeredOutOfTreeMultiPointName = []string{}
-)
+var outOfTreeRegistries = runtime.Registry{
+	// TODO(user): add your plugins registries here.
+}
 
 // RegisteredMultiPointPluginNames returns all registered multipoint plugin names.
 // in-tree plugins and your original plugins listed in outOfTreeRegistries above.
@@ -43,6 +39,10 @@ func InTreeMultiPointPluginSet() (configv1.PluginSet, error) {
 }
 
 func OutOfTreeMultiPointPluginNames() []string {
+	registeredOutOfTreeMultiPointName := make([]string, 0, len(outOfTreeRegistries))
+	for k := range outOfTreeRegistries {
+		registeredOutOfTreeMultiPointName = append(registeredOutOfTreeMultiPointName, k)
+	}
 	return registeredOutOfTreeMultiPointName
 }
 
@@ -57,6 +57,5 @@ func OutOfTreeRegistries() runtime.Registry {
 func SetOutOfTreeRegistries(r runtime.Registry) {
 	for k, v := range r {
 		outOfTreeRegistries[k] = v
-		registeredOutOfTreeMultiPointName = append(registeredOutOfTreeMultiPointName, k)
 	}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/area simulator
/kind bug

<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Before this PR, users had to register their custom plugin names in `registeredOutOfTreeMultiPointName`. 
This is undocumented and led to this kind of issue: https://github.com/kubernetes-sigs/kube-scheduler-simulator/issues/311.

This PR eliminates the need to register `registeredOutOfTreeMultiPointName` in the first place, rather than documenting the existence of `registeredOutOfTreeMultiPointName`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #311

#### Special notes for your reviewer:


/label tide/merge-method-squash
