### PR TITLE
Not trying to load a default kubeconfig when a kubeconfig is passed

### DIFF
--- a/simulator/pkg/debuggablescheduler/debuggable_scheduler.go
+++ b/simulator/pkg/debuggablescheduler/debuggable_scheduler.go
@@ -77,16 +77,21 @@ func CreateOptionForOutOfTreePlugin(outOfTreePluginRegistry runtime.Registry, pl
 	if err != nil {
 		return nil, nil, xerrors.Errorf("convert scheduler config to apply: %w", err)
 	}
-	kubeconfig, err := simulatorconfig.GetKubeClientConfig()
-	if err != nil {
-		return nil, nil, xerrors.Errorf("get kubeconfig: %w", err)
-	}
+
+	var kubeconfig *restclient.Config
 	if internalCfg.ClientConnection.Kubeconfig != "" {
 		kubeconfig, err = createKubeConfig(internalCfg.ClientConnection, *master)
 		if err != nil {
 			return nil, nil, xerrors.Errorf("get kubeconfig specified in config: %w", err)
 		}
+	} else {
+		// If the kubeconfig is not specified in the configuration, the simulator will use the default kubeconfig.
+		kubeconfig, err = simulatorconfig.GetKubeClientConfig()
+		if err != nil {
+			return nil, nil, xerrors.Errorf("get kubeconfig: %w", err)
+		}
 	}
+
 	clientSet, err := clientset.NewForConfig(kubeconfig)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("creates a new Clientset for kubeconfig: %w", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/area simulator
/kind cleanup

<!--
Add related area tag(s):

Add one of the following kinds:
/kind cleanup

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Before this PR, the simulator attempts to load a default kubeconfig event if a kubeconfig is passed.
This PR removes this waste. 

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #336

#### Special notes for your reviewer:


/label tide/merge-method-squash
