### PR TITLE
Use docker compose instead of docker-compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,19 +41,19 @@ docker_build_front:
 
 .PHONY: docker_up
 docker_up:
-	docker-compose up -d
+	docker compose up -d
 
 .PHONY: docker_up_local
 docker_up_local:
-	docker-compose -f docker-compose-local.yml up -d
+	docker compose -f docker-compose-local.yml up -d
 
 .PHONY: docker_build_and_up
 docker_build_and_up: docker_build docker_up_local
 
 .PHONY: docker_down
 docker_down:
-	docker-compose down --volumes
+	docker compose down --volumes
 
 .PHONY: docker_down_local
 docker_down_local:
-	docker-compose -f docker-compose-local.yml down
+	docker compose -f docker-compose-local.yml down

--- a/simulator/docs/running-simulator.md
+++ b/simulator/docs/running-simulator.md
@@ -22,7 +22,7 @@ make docker_build_and_up
 
 Then, you can access the simulator with http://localhost:3000.
 If you want to deploy the simulator on a remote server and access it via a specific IP (e.g: like http://10.0.0.1:3000/),
-please make sure that you have executed `export SIMULATOR_EXTERNAL_IP=your.server.ip` before running `docker-compose up -d`.
+please make sure that you have executed `export SIMULATOR_EXTERNAL_IP=your.server.ip` before running `docker compose up -d`.
 
 ### Run simulator without docker
 


### PR DESCRIPTION
#### What type of PR is this?

/area simulator
/kind cleanup

<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Nowadays, we don't need to install `docker-compose`. We can use `docker compose` instead of that.
Also, it means we use docker compose v2, however as far as I know, it doesn't affect our use cases.
https://docs.docker.com/compose/migrate/

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
None

#### Special notes for your reviewer:


/label tide/merge-method-squash
