### PR TITLE
Fix Default Config Loading When ConfigFile Is Not Specified

### DIFF
--- a/simulator/pkg/debuggablescheduler/debuggable_scheduler.go
+++ b/simulator/pkg/debuggablescheduler/debuggable_scheduler.go
@@ -138,7 +138,7 @@ func CreateOptionForPlugin(outOfTreePluginRegistry runtime.Registry, pluginExten
 func loadKubeSchedulerConfig(configFile *string) (*v1.KubeSchedulerConfiguration, error) {
 	var versionedcfg *v1.KubeSchedulerConfiguration
 	var err error
-	if configFile == nil {
+	if configFile == nil || *configFile == ""{
 		versionedcfg, err = simulatorschedulerconfig.DefaultSchedulerConfig()
 		if err != nil {
 			return nil, xerrors.Errorf("get default scheduler config: %w", err)

--- a/simulator/pkg/debuggablescheduler/debuggable_scheduler.go
+++ b/simulator/pkg/debuggablescheduler/debuggable_scheduler.go
@@ -138,7 +138,7 @@ func CreateOptionForPlugin(outOfTreePluginRegistry runtime.Registry, pluginExten
 func loadKubeSchedulerConfig(configFile *string) (*v1.KubeSchedulerConfiguration, error) {
 	var versionedcfg *v1.KubeSchedulerConfiguration
 	var err error
-	if configFile == nil || *configFile == ""{
+	if configFile == nil || *configFile == "" {
 		versionedcfg, err = simulatorschedulerconfig.DefaultSchedulerConfig()
 		if err != nil {
 			return nil, xerrors.Errorf("get default scheduler config: %w", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

Add related area tag(s):
/area simulator

Add one of the following kinds:
/kind bug


#### What this PR does / why we need it:

The `debuggableScheduler` aims to load the default configuration when no explicit `configfile` is provided. However, the current condition to check the `configFile` fails because it only verifies if the pointer is `nil`. When the pointer contains an empty string, it bypasses the default config loading logic.

To address this issue, we have added a new condition to check whether the value of `configFile` is an empty string, ensuring the default configuration is loaded as expected when no config file is specified.


#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes https://github.com/kubernetes-sigs/kube-scheduler-simulator/issues/375

#### Special notes for your reviewer:


/label tide/merge-method-squash

I'm preparing a presentation about kube-scheduler in Taiwan this week, I would like to use the kube-scheduler-simulator to demonstrate the mechanism. 
During preparation I found this bug, therefore I opened a PR to fix it. 
This is my first PR in CNCF, and I’m excited to contribute! If you have any questions, please feel free to reach out.
