### PR TITLE
fix: invalid empty services fields in compose.local.yml

### DIFF
--- a/compose.local.yml
+++ b/compose.local.yml
@@ -4,7 +4,7 @@ version: "3.7"
 services:
   # This container copies the data,
   # so any changes made to the configuration files within the Pod will not affect the original files.
-  init-container:
+  init-container: {}
   simulator-scheduler:
     image: simulator-scheduler
   simulator-server:
@@ -15,7 +15,7 @@ services:
         required: false
   simulator-frontend:
     image: simulator-frontend
-  simulator-cluster:
+  simulator-cluster: {}
   fake-source-cluster:
     image: registry.k8s.io/kwok/cluster:v0.6.0-k8s.v1.30.2
     container_name: fake-source-cluster


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

A fix for `make docker_up_local` and `make docker_down_local` due to invalid empty fields in `compose.local.yaml`.

<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Running the following command `make docker_up_local` results in an error:
```
$ make docker_down_local         
docker compose -f compose.yml -f compose.local.yml down --volumes
validating /Users/zele/Projects/go-k8s-wasm/dejanzele/kube-scheduler-simulator/compose.local.yml: services.simulator-cluster must be a mapping
make: *** [Makefile:77: docker_down_local] Error 15
```

Docker compose complains about empty fields in the `services` block defined like the following:
```
services:
  init-container:
```

This PR just adds empty objects to the affected fields

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:


/label tide/merge-method-squash
