### PR TITLE
feat: allow user to configure extenders via web UI

### DIFF
--- a/simulator/server/handler/schedulerconfig.go
+++ b/simulator/server/handler/schedulerconfig.go
@@ -36,7 +36,8 @@ func (h *SchedulerConfigHandler) GetSchedulerConfig(c echo.Context) error {
 	return c.JSON(http.StatusOK, cfg)
 }
 
-// ApplySchedulerConfig currently only takes profiles from the posted payload and applies them.
+// ApplySchedulerConfig currently only takes profiles and extenders from the
+// posted payload and applies them.
 func (h *SchedulerConfigHandler) ApplySchedulerConfig(c echo.Context) error {
 	reqSchedulerCfg := new(configv1.KubeSchedulerConfiguration)
 	if err := c.Bind(reqSchedulerCfg); err != nil {
@@ -51,6 +52,7 @@ func (h *SchedulerConfigHandler) ApplySchedulerConfig(c echo.Context) error {
 
 	cfg = cfg.DeepCopy()
 	cfg.Profiles = reqSchedulerCfg.Profiles
+	cfg.Extenders = reqSchedulerCfg.Extenders
 	if err := h.service.RestartScheduler(cfg); err != nil {
 		klog.Errorf("failed to restart scheduler: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/area simulator
/kind feature

#### What this PR does / why we need it:

Even though the `Extender` documentation mentioned the ability to add `extenders` to the scheduler configuration via the Web UI, this wasn't actually supported.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

#### Special notes for your reviewer:

/label tide/merge-method-squash
