### PR TITLE
fix(simulator): register the out-of-tree plugins before initializing configurations

### DIFF
--- a/simulator/pkg/debuggablescheduler/command.go
+++ b/simulator/pkg/debuggablescheduler/command.go
@@ -5,6 +5,7 @@ import (
 	"golang.org/x/xerrors"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
+	simulatorschedulerconfig "sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/config"
 
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/extender"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/plugin"
@@ -15,6 +16,11 @@ func NewSchedulerCommand(opts ...Option) (*cobra.Command, func(), error) {
 	for _, o := range opts {
 		o(opt)
 	}
+
+	if opt.outOfTreeRegistry != nil {
+		simulatorschedulerconfig.SetOutOfTreeRegistries(opt.outOfTreeRegistry)
+	}
+
 	configs, err := NewConfigs()
 	if err != nil {
 		return nil, nil, xerrors.Errorf("failed to NewConfigs(): %w", err)
@@ -27,7 +33,7 @@ func NewSchedulerCommand(opts ...Option) (*cobra.Command, func(), error) {
 		return nil, nil, xerrors.Errorf("failed to New Extender service: %w", err)
 	}
 
-	schedulerOpts, cancelFn, err := CreateOptions(configs, opt.outOfTreeRegistry, opt.pluginExtender)
+	schedulerOpts, cancelFn, err := CreateOptions(configs, opt.pluginExtender)
 	if err != nil {
 		return nil, cancelFn, err
 	}

--- a/simulator/pkg/debuggablescheduler/command.go
+++ b/simulator/pkg/debuggablescheduler/command.go
@@ -5,8 +5,8 @@ import (
 	"golang.org/x/xerrors"
 	"k8s.io/kubernetes/cmd/kube-scheduler/app"
 	"k8s.io/kubernetes/pkg/scheduler/framework/runtime"
-	simulatorschedulerconfig "sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/config"
 
+	simulatorschedulerconfig "sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/config"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/extender"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler/plugin"
 )

--- a/simulator/pkg/debuggablescheduler/debuggable_scheduler.go
+++ b/simulator/pkg/debuggablescheduler/debuggable_scheduler.go
@@ -91,11 +91,11 @@ func NewConfigs() (Configs, error) {
 // and resister the storereflector to informer.
 // Then, here makes the defaulting func of the KubeSchedulerConfig always returns the converted one.
 // We can let the scheduler use the converted configuration under any circumstances because the scheduler will always use this defaulting func to load the configuration.
-func CreateOptions(configs Configs, outOfTreePluginRegistry runtime.Registry, pluginExtender map[string]plugin.PluginExtenderInitializer) ([]app.Option, func(), error) {
+func CreateOptions(configs Configs, pluginExtender map[string]plugin.PluginExtenderInitializer) ([]app.Option, func(), error) {
 	// Override the Extenders config so that the connection is directed to the simulator server.
 	extender.OverrideExtendersCfgToSimulator(configs.versioned, configs.port)
 
-	opts, err := CreateOptionForPlugin(outOfTreePluginRegistry, pluginExtender, configs.sharedStore, configs.internalCfg)
+	opts, err := CreateOptionForPlugin(pluginExtender, configs.sharedStore, configs.internalCfg)
 	if err != nil {
 		return nil, nil, xerrors.Errorf("CreateOptionForPlugin: %w", err)
 	}
@@ -125,12 +125,7 @@ func CreateOptions(configs Configs, outOfTreePluginRegistry runtime.Registry, pl
 
 // CreateOptionForPlugin creates Option for in/out of tree plugins.
 // It does create the wrapped plugin registries and return the registries as app.Option.
-func CreateOptionForPlugin(outOfTreePluginRegistry runtime.Registry, pluginExtender map[string]plugin.PluginExtenderInitializer, sharedStore storereflector.Reflector, internalCfg *config.KubeSchedulerConfiguration) ([]app.Option, error) {
-	if outOfTreePluginRegistry != nil {
-		// This must be called before plugin.NewRegistry().
-		simulatorschedulerconfig.SetOutOfTreeRegistries(outOfTreePluginRegistry)
-	}
-
+func CreateOptionForPlugin(pluginExtender map[string]plugin.PluginExtenderInitializer, sharedStore storereflector.Reflector, internalCfg *config.KubeSchedulerConfiguration) ([]app.Option, error) {
 	// loads in/out of tree plugins and wraps it for debuggable.
 	registry, err := plugin.NewRegistry(sharedStore, internalCfg, pluginExtender)
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
bug
<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Lack of adding user-defined plug-in configuration to defaultpls, resulting in loss of user configuration
#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes # Safeguard user expectations

#### Special notes for your reviewer:


/label tide/merge-method-squash
