### PR TITLE
Separate the logic of applying resources from syncer and make it reusable

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -5,7 +5,7 @@ services:
       image: busybox
       volumes:
         - conf:/config
-        - ${PWD}/simulator/cmd/scheduler:/host-config:ro    
+        - ${PWD}/simulator/cmd/scheduler:/host-config:ro
       command: sh -c "cp -rf /host-config/* /config/"
   simulator-scheduler:
     image: registry.k8s.io/scheduler-simulator/debuggable-scheduler:v0.4.0

--- a/simulator/cmd/simulator/simulator.go
+++ b/simulator/cmd/simulator/simulator.go
@@ -23,7 +23,6 @@ import (
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/resourceapplier"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/server"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/server/di"
-	"sigs.k8s.io/kube-scheduler-simulator/simulator/syncer"
 )
 
 const (
@@ -95,7 +94,7 @@ func startSimulator() error {
 		return xerrors.Errorf("kubeapi-server is not ready: %w", err)
 	}
 
-	dic, err := di.NewDIContainer(client, dynamicClient, restMapper, etcdclient, restCfg, cfg.InitialSchedulerCfg, cfg.ExternalImportEnabled, cfg.ResourceSyncEnabled, importClusterResourceClient, importClusterDynamicClient, cfg.Port, syncer.Options{}, resourceapplier.Options{})
+	dic, err := di.NewDIContainer(client, dynamicClient, restMapper, etcdclient, restCfg, cfg.InitialSchedulerCfg, cfg.ExternalImportEnabled, cfg.ResourceSyncEnabled, importClusterResourceClient, importClusterDynamicClient, cfg.Port, resourceapplier.Options{})
 	if err != nil {
 		return xerrors.Errorf("create di container: %w", err)
 	}

--- a/simulator/cmd/simulator/simulator.go
+++ b/simulator/cmd/simulator/simulator.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/klog/v2"
 
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/config"
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/resourceapplier"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/server"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/server/di"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/syncer"
@@ -94,7 +95,7 @@ func startSimulator() error {
 		return xerrors.Errorf("kubeapi-server is not ready: %w", err)
 	}
 
-	dic, err := di.NewDIContainer(client, dynamicClient, restMapper, etcdclient, restCfg, cfg.InitialSchedulerCfg, cfg.ExternalImportEnabled, cfg.ResourceSyncEnabled, importClusterResourceClient, importClusterDynamicClient, cfg.Port, syncer.Options{})
+	dic, err := di.NewDIContainer(client, dynamicClient, restMapper, etcdclient, restCfg, cfg.InitialSchedulerCfg, cfg.ExternalImportEnabled, cfg.ResourceSyncEnabled, importClusterResourceClient, importClusterDynamicClient, cfg.Port, syncer.Options{}, resourceapplier.Options{})
 	if err != nil {
 		return xerrors.Errorf("create di container: %w", err)
 	}

--- a/simulator/docs/import-cluster-resources.md
+++ b/simulator/docs/import-cluster-resources.md
@@ -72,16 +72,21 @@ dic, err := di.NewDIContainer(..., syncer.Options{
 	// GVRsToSync is a list of GroupVersionResource that will be synced.
 	// If GVRsToSync is nil, defaultGVRs are used.
 	GVRsToSync: []schema.GroupVersionResource{
-    		{Group: "your-group", Version: "v1", Resource: "your-custom-resources"},
-  	}
-
+		{Group: "your-group", Version: "v1", Resource: "your-custom-resources"},
+	},
+},
 	// Actually, more options are available...
- 
-	// AdditionalMutatingFunctions is a list of mutating functions that users add.
-	AdditionalMutatingFunctions:  map[schema.GroupVersionResource]MutatingFunction{...}
-	// AdditionalFilteringFunctions is a list of filtering functions that users add.
-	AdditionalFilteringFunctions: map[schema.GroupVersionResource]FilteringFunction{...}
-})
+	resourceapplier.Options{
+		// FilterBeforeCreating is a list of additional filtering functions that are applied before creating resources.
+		FilterBeforeCreating: map[schema.GroupVersionResource][]resourceapplier.FilteringFunction{...},
+		// MutateBeforeCreating is a list of additional mutating functions that are applied before creating resources.
+		MutateBeforeCreating: map[schema.GroupVersionResource][]resourceapplier.MutatingFunction{...},
+		// FilterBeforeUpdating is a list of additional filtering functions that are applied before updating resources.
+		FilterBeforeUpdating: map[schema.GroupVersionResource][]resourceapplier.FilteringFunction{...},
+		// MutateBeforeUpdating is a list of additional mutating functions that are applied before updating resources.
+		MutateBeforeUpdating: map[schema.GroupVersionResource][]resourceapplier.MutatingFunction{...},
+	},
+)
 ```
 
 > [!NOTE]

--- a/simulator/docs/import-cluster-resources.md
+++ b/simulator/docs/import-cluster-resources.md
@@ -68,25 +68,24 @@ It imports the following resources, which the scheduler's default plugins take i
 If you need to, you can tweak which resources to import via the option in [/simulator/cmd/simulator/simulator.go](https://github.com/kubernetes-sigs/kube-scheduler-simulator/blob/master/simulator/cmd/simulator/simulator.go):
 
 ```go
-dic, err := di.NewDIContainer(..., syncer.Options{
+dic, err := di.NewDIContainer(..., resourceapplier.Options{
 	// GVRsToSync is a list of GroupVersionResource that will be synced.
 	// If GVRsToSync is nil, defaultGVRs are used.
 	GVRsToSync: []schema.GroupVersionResource{
 		{Group: "your-group", Version: "v1", Resource: "your-custom-resources"},
 	},
-},
+
 	// Actually, more options are available...
-	resourceapplier.Options{
-		// FilterBeforeCreating is a list of additional filtering functions that are applied before creating resources.
-		FilterBeforeCreating: map[schema.GroupVersionResource][]resourceapplier.FilteringFunction{...},
-		// MutateBeforeCreating is a list of additional mutating functions that are applied before creating resources.
-		MutateBeforeCreating: map[schema.GroupVersionResource][]resourceapplier.MutatingFunction{...},
-		// FilterBeforeUpdating is a list of additional filtering functions that are applied before updating resources.
-		FilterBeforeUpdating: map[schema.GroupVersionResource][]resourceapplier.FilteringFunction{...},
-		// MutateBeforeUpdating is a list of additional mutating functions that are applied before updating resources.
-		MutateBeforeUpdating: map[schema.GroupVersionResource][]resourceapplier.MutatingFunction{...},
-	},
-)
+
+	// FilterBeforeCreating is a list of additional filtering functions that are applied before creating resources.
+	FilterBeforeCreating: map[schema.GroupVersionResource][]resourceapplier.FilteringFunction{},
+	// MutateBeforeCreating is a list of additional mutating functions that are applied before creating resources.
+	MutateBeforeCreating: map[schema.GroupVersionResource][]resourceapplier.MutatingFunction{},
+	// FilterBeforeUpdating is a list of additional filtering functions that are applied before updating resources.
+	FilterBeforeUpdating: map[schema.GroupVersionResource][]resourceapplier.FilteringFunction{},
+	// MutateBeforeUpdating is a list of additional mutating functions that are applied before updating resources.
+	MutateBeforeUpdating: map[schema.GroupVersionResource][]resourceapplier.MutatingFunction{},
+})
 ```
 
 > [!NOTE]

--- a/simulator/resourceapplier/resourceapplier.go
+++ b/simulator/resourceapplier/resourceapplier.go
@@ -55,45 +55,29 @@ func New(dynamicClient dynamic.Interface, restMapper meta.RESTMapper, options Op
 	}
 
 	for gvr, fn := range mandatoryFilterForCreating {
-		s.filterBeforeCreating[gvr] = []FilteringFunction{fn}
+		s.addFilterBeforeCreating(gvr, []FilteringFunction{fn})
 	}
 	for gvr, fn := range mandatoryMutateForCreating {
-		s.mutateBeforeCreating[gvr] = []MutatingFunction{fn}
+		s.addMutateBeforeCreating(gvr, []MutatingFunction{fn})
 	}
 	for gvr, fn := range mandatoryFilterForUpdating {
-		s.filterBeforeUpdating[gvr] = []FilteringFunction{fn}
+		s.addFilterBeforeUpdating(gvr, []FilteringFunction{fn})
 	}
 	for gvr, fn := range mandatoryMutateForUpdating {
-		s.mutateBeforeUpdating[gvr] = []MutatingFunction{fn}
+		s.addMutateBeforeUpdating(gvr, []MutatingFunction{fn})
 	}
 
 	for gvr, fns := range options.FilterBeforeCreating {
-		if _, ok := s.filterBeforeCreating[gvr]; !ok {
-			s.filterBeforeCreating[gvr] = []FilteringFunction{}
-		}
-
-		s.filterBeforeCreating[gvr] = append(s.filterBeforeCreating[gvr], fns...)
+		s.addFilterBeforeCreating(gvr, fns)
 	}
 	for gvr, fns := range options.MutateBeforeCreating {
-		if _, ok := s.mutateBeforeCreating[gvr]; !ok {
-			s.mutateBeforeCreating[gvr] = []MutatingFunction{}
-		}
-
-		s.mutateBeforeCreating[gvr] = append(s.mutateBeforeCreating[gvr], fns...)
+		s.addMutateBeforeCreating(gvr, fns)
 	}
 	for gvr, fns := range options.FilterBeforeUpdating {
-		if _, ok := s.filterBeforeUpdating[gvr]; !ok {
-			s.filterBeforeUpdating[gvr] = []FilteringFunction{}
-		}
-
-		s.filterBeforeUpdating[gvr] = append(s.filterBeforeUpdating[gvr], fns...)
+		s.addFilterBeforeUpdating(gvr, fns)
 	}
 	for gvr, fns := range options.MutateBeforeUpdating {
-		if _, ok := s.mutateBeforeUpdating[gvr]; !ok {
-			s.mutateBeforeUpdating[gvr] = []MutatingFunction{}
-		}
-
-		s.mutateBeforeUpdating[gvr] = append(s.mutateBeforeUpdating[gvr], fns...)
+		s.addMutateBeforeUpdating(gvr, fns)
 	}
 
 	return s
@@ -293,4 +277,36 @@ func removeUnnecessaryMetadata(resource *unstructured.Unstructured) *unstructure
 	resource.SetResourceVersion("")
 
 	return resource
+}
+
+func (s *Service) addFilterBeforeCreating(gvr schema.GroupVersionResource, fn []FilteringFunction) {
+	if _, ok := s.filterBeforeCreating[gvr]; !ok {
+		s.filterBeforeCreating[gvr] = []FilteringFunction{}
+	}
+
+	s.filterBeforeCreating[gvr] = append(s.filterBeforeCreating[gvr], fn...)
+}
+
+func (s *Service) addMutateBeforeCreating(gvr schema.GroupVersionResource, fn []MutatingFunction) {
+	if _, ok := s.mutateBeforeCreating[gvr]; !ok {
+		s.mutateBeforeCreating[gvr] = []MutatingFunction{}
+	}
+
+	s.mutateBeforeCreating[gvr] = append(s.mutateBeforeCreating[gvr], fn...)
+}
+
+func (s *Service) addFilterBeforeUpdating(gvr schema.GroupVersionResource, fn []FilteringFunction) {
+	if _, ok := s.filterBeforeUpdating[gvr]; !ok {
+		s.filterBeforeUpdating[gvr] = []FilteringFunction{}
+	}
+
+	s.filterBeforeUpdating[gvr] = append(s.filterBeforeUpdating[gvr], fn...)
+}
+
+func (s *Service) addMutateBeforeUpdating(gvr schema.GroupVersionResource, fn []MutatingFunction) {
+	if _, ok := s.mutateBeforeUpdating[gvr]; !ok {
+		s.mutateBeforeUpdating[gvr] = []MutatingFunction{}
+	}
+
+	s.mutateBeforeUpdating[gvr] = append(s.mutateBeforeUpdating[gvr], fn...)
 }

--- a/simulator/resourceapplier/resourceapplier.go
+++ b/simulator/resourceapplier/resourceapplier.go
@@ -1,0 +1,296 @@
+package resourceapplier
+
+import (
+	"context"
+
+	"golang.org/x/xerrors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+// FilteringFunction is a function that filters a resource.
+// If it returns false, the resource will not be imported.
+type FilteringFunction func(ctx context.Context, resource *unstructured.Unstructured, clients *Clients) (bool, error)
+
+// MutatingFunction is a function that mutates a resource before importing it.
+type MutatingFunction func(ctx context.Context, resource *unstructured.Unstructured, clients *Clients) (*unstructured.Unstructured, error)
+
+// Note: Clients and its fields are exposed intentionally so that users can use it in MutatingFunction and FilteringFunction.
+type Clients struct {
+	// DynamicClient is the dynamic client for the destination cluster, which the resource is supposed to be copied to.
+	DynamicClient dynamic.Interface
+	RestMapper    meta.RESTMapper
+}
+
+type Options struct {
+	FilterBeforeCreating map[schema.GroupVersionResource][]FilteringFunction
+	MutateBeforeCreating map[schema.GroupVersionResource][]MutatingFunction
+	FilterBeforeUpdating map[schema.GroupVersionResource][]FilteringFunction
+	MutateBeforeUpdating map[schema.GroupVersionResource][]MutatingFunction
+}
+
+type Service struct {
+	clients *Clients
+
+	mutateBeforeCreating map[schema.GroupVersionResource][]MutatingFunction
+	filterBeforeCreating map[schema.GroupVersionResource][]FilteringFunction
+	mutateBeforeUpdating map[schema.GroupVersionResource][]MutatingFunction
+	filterBeforeUpdating map[schema.GroupVersionResource][]FilteringFunction
+}
+
+func New(dynamicClient dynamic.Interface, restMapper meta.RESTMapper, options Options) *Service {
+	s := &Service{
+		clients: &Clients{
+			DynamicClient: dynamicClient,
+			RestMapper:    restMapper,
+		},
+
+		filterBeforeCreating: map[schema.GroupVersionResource][]FilteringFunction{},
+		mutateBeforeCreating: map[schema.GroupVersionResource][]MutatingFunction{},
+		filterBeforeUpdating: map[schema.GroupVersionResource][]FilteringFunction{},
+		mutateBeforeUpdating: map[schema.GroupVersionResource][]MutatingFunction{},
+	}
+
+	for gvr, fn := range mandatoryFilterForCreating {
+		s.filterBeforeCreating[gvr] = []FilteringFunction{fn}
+	}
+	for gvr, fn := range mandatoryMutateForCreating {
+		s.mutateBeforeCreating[gvr] = []MutatingFunction{fn}
+	}
+	for gvr, fn := range mandatoryFilterForUpdating {
+		s.filterBeforeUpdating[gvr] = []FilteringFunction{fn}
+	}
+	for gvr, fn := range mandatoryMutateForUpdating {
+		s.mutateBeforeUpdating[gvr] = []MutatingFunction{fn}
+	}
+
+	for gvr, fns := range options.FilterBeforeCreating {
+		if _, ok := s.filterBeforeCreating[gvr]; !ok {
+			s.filterBeforeCreating[gvr] = []FilteringFunction{}
+		}
+
+		s.filterBeforeCreating[gvr] = append(s.filterBeforeCreating[gvr], fns...)
+	}
+	for gvr, fns := range options.MutateBeforeCreating {
+		if _, ok := s.mutateBeforeCreating[gvr]; !ok {
+			s.mutateBeforeCreating[gvr] = []MutatingFunction{}
+		}
+
+		s.mutateBeforeCreating[gvr] = append(s.mutateBeforeCreating[gvr], fns...)
+	}
+	for gvr, fns := range options.FilterBeforeUpdating {
+		if _, ok := s.filterBeforeUpdating[gvr]; !ok {
+			s.filterBeforeUpdating[gvr] = []FilteringFunction{}
+		}
+
+		s.filterBeforeUpdating[gvr] = append(s.filterBeforeUpdating[gvr], fns...)
+	}
+	for gvr, fns := range options.MutateBeforeUpdating {
+		if _, ok := s.mutateBeforeUpdating[gvr]; !ok {
+			s.mutateBeforeUpdating[gvr] = []MutatingFunction{}
+		}
+
+		s.mutateBeforeUpdating[gvr] = append(s.mutateBeforeUpdating[gvr], fns...)
+	}
+
+	return s
+}
+
+func (s *Service) Create(ctx context.Context, resource *unstructured.Unstructured) error {
+	// Extract the GroupVersionResource from the Unstructured object
+	gvk := resource.GroupVersionKind()
+	gvr, err := s.findGVRForGVK(gvk)
+	if err != nil {
+		return err
+	}
+
+	// Namespaces resources should be created within the namespace defined in the Unstructured object
+	namespace := resource.GetNamespace()
+
+	// Run the filtering function for the resource.
+	if ok, err := s.filterResourceForCreating(ctx, gvr, resource, s.clients); !ok || err != nil {
+		return err
+	}
+
+	// When creating a resource on the destination cluster, we must remove the metadata such as UID and Generation.
+	// It's done for all resources.
+	resource = removeUnnecessaryMetadata(resource)
+
+	// Run the mutating function for the resource.
+	resource, err = s.mutateResourceForCreating(ctx, gvr, resource, s.clients)
+	if err != nil {
+		return xerrors.Errorf("failed to mutate resource: %w", err)
+	}
+
+	// Create the resource on the destination cluster using the dynamic client
+	_, err = s.clients.DynamicClient.Resource(gvr).Namespace(namespace).Create(
+		ctx,
+		resource,
+		metav1.CreateOptions{},
+	)
+	if err != nil {
+		return xerrors.Errorf("failed to create resource: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) Update(ctx context.Context, resource *unstructured.Unstructured) error {
+	// Extract the GroupVersionResource from the Unstructured object
+	gvk := resource.GroupVersionKind()
+	gvr, err := s.findGVRForGVK(gvk)
+	if err != nil {
+		return err
+	}
+
+	// Namespaces resources should be created within the namespace defined in the Unstructured object
+	namespace := resource.GetNamespace()
+
+	// Run the filtering function for the resource.
+	if ok, err := s.filterResourceForUpdating(ctx, gvr, resource, s.clients); !ok || err != nil {
+		return err
+	}
+
+	// When updating a resource on the destination cluster, we must remove the metadata such as UID and Generation.
+	// It's done for all resources.
+	resource = removeUnnecessaryMetadata(resource)
+
+	// Run the mutating function for the resource.
+	resource, err = s.mutateResourceForUpdating(ctx, gvr, resource, s.clients)
+	if err != nil {
+		return xerrors.Errorf("failed to mutate resource: %w", err)
+	}
+
+	// Update the resource on the destination cluster using the dynamic client
+	_, err = s.clients.DynamicClient.Resource(gvr).Namespace(namespace).Update(
+		ctx,
+		resource,
+		metav1.UpdateOptions{},
+	)
+	if err != nil {
+		return xerrors.Errorf("failed to update resource: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) Delete(
+	ctx context.Context,
+	resource *unstructured.Unstructured,
+) error {
+	// Extract the GroupVersionResource from the Unstructured object
+	gvk := resource.GroupVersionKind()
+	gvr, err := s.findGVRForGVK(gvk)
+	if err != nil {
+		return err
+	}
+
+	// Namespaces resources should be created within the namespace defined in the Unstructured object
+	namespace := resource.GetNamespace()
+
+	// Create the resource on the destination cluster using the dynamic client
+	err = s.clients.DynamicClient.Resource(gvr).Namespace(namespace).Delete(
+		ctx,
+		resource.GetName(),
+		metav1.DeleteOptions{},
+	)
+	if err != nil {
+		return xerrors.Errorf("failed to delete resource: %w", err)
+	}
+
+	return nil
+}
+
+func (s *Service) filterResourceForCreating(ctx context.Context, gvr schema.GroupVersionResource, resource *unstructured.Unstructured, clients *Clients) (bool, error) {
+	filteringFns, ok := s.filterBeforeCreating[gvr]
+	if !ok {
+		return true, nil
+	}
+
+	for _, filteringFn := range filteringFns {
+		ok, err := filteringFn(ctx, resource, clients)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (s *Service) mutateResourceForCreating(ctx context.Context, gvr schema.GroupVersionResource, resource *unstructured.Unstructured, clients *Clients) (*unstructured.Unstructured, error) {
+	mutatingFns, ok := s.mutateBeforeCreating[gvr]
+	if !ok {
+		return resource, nil
+	}
+
+	for _, mutatingFn := range mutatingFns {
+		modifiedResource, err := mutatingFn(ctx, resource, clients)
+		if err != nil {
+			return nil, err
+		}
+		resource = modifiedResource
+	}
+
+	return resource, nil
+}
+
+func (s *Service) filterResourceForUpdating(ctx context.Context, gvr schema.GroupVersionResource, resource *unstructured.Unstructured, clients *Clients) (bool, error) {
+	filteringFns, ok := s.filterBeforeUpdating[gvr]
+	if !ok {
+		return true, nil
+	}
+
+	for _, filteringFn := range filteringFns {
+		ok, err := filteringFn(ctx, resource, clients)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func (s *Service) mutateResourceForUpdating(ctx context.Context, gvr schema.GroupVersionResource, resource *unstructured.Unstructured, clients *Clients) (*unstructured.Unstructured, error) {
+	mutatingFns, ok := s.mutateBeforeUpdating[gvr]
+	if !ok {
+		return resource, nil
+	}
+
+	for _, mutatingFn := range mutatingFns {
+		modifiedResource, err := mutatingFn(ctx, resource, clients)
+		if err != nil {
+			return nil, err
+		}
+		resource = modifiedResource
+	}
+
+	return resource, nil
+}
+
+// findGVRForGVK uses the discovery client to get the GroupVersionResource for a given GroupVersionKind.
+func (s *Service) findGVRForGVK(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+	m, err := s.clients.RestMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+
+	return m.Resource, nil
+}
+
+// removeUnnecessaryMetadata removes the metadata from the resource.
+func removeUnnecessaryMetadata(resource *unstructured.Unstructured) *unstructured.Unstructured {
+	resource.SetUID("")
+	resource.SetGeneration(0)
+	resource.SetResourceVersion("")
+
+	return resource
+}

--- a/simulator/resourceapplier/resourceapplier.go
+++ b/simulator/resourceapplier/resourceapplier.go
@@ -26,6 +26,7 @@ type Clients struct {
 }
 
 type Options struct {
+	GVRsToSync           []schema.GroupVersionResource
 	FilterBeforeCreating map[schema.GroupVersionResource][]FilteringFunction
 	MutateBeforeCreating map[schema.GroupVersionResource][]MutatingFunction
 	FilterBeforeUpdating map[schema.GroupVersionResource][]FilteringFunction
@@ -39,6 +40,8 @@ type Service struct {
 	filterBeforeCreating map[schema.GroupVersionResource][]FilteringFunction
 	mutateBeforeUpdating map[schema.GroupVersionResource][]MutatingFunction
 	filterBeforeUpdating map[schema.GroupVersionResource][]FilteringFunction
+
+	GVRsToSync []schema.GroupVersionResource
 }
 
 func New(dynamicClient dynamic.Interface, restMapper meta.RESTMapper, options Options) *Service {
@@ -52,6 +55,8 @@ func New(dynamicClient dynamic.Interface, restMapper meta.RESTMapper, options Op
 		mutateBeforeCreating: map[schema.GroupVersionResource][]MutatingFunction{},
 		filterBeforeUpdating: map[schema.GroupVersionResource][]FilteringFunction{},
 		mutateBeforeUpdating: map[schema.GroupVersionResource][]MutatingFunction{},
+
+		GVRsToSync: options.GVRsToSync,
 	}
 
 	for gvr, fn := range mandatoryFilterForCreating {

--- a/simulator/resourceapplier/resourceapplier_test.go
+++ b/simulator/resourceapplier/resourceapplier_test.go
@@ -1,0 +1,616 @@
+package resourceapplier
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicFake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/restmapper"
+	scheduling "k8s.io/kubernetes/pkg/apis/scheduling/v1"
+	storage "k8s.io/kubernetes/pkg/apis/storage/v1"
+)
+
+func TestResourceApplier_createPods(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		podToApply    *corev1.Pod
+		podAfterApply *corev1.Pod
+		wantErr       bool
+	}{
+		{
+			name: "create a Pod",
+			podToApply: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-1",
+						},
+					},
+				},
+			},
+			podAfterApply: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-1",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := runtime.NewScheme()
+			v1.AddToScheme(s)
+			scheduling.AddToScheme(s)
+			storage.AddToScheme(s)
+			client := dynamicFake.NewSimpleDynamicClient(s)
+			resources := []*restmapper.APIGroupResources{
+				{
+					Group: metav1.APIGroup{
+						Versions: []metav1.GroupVersionForDiscovery{
+							{Version: "v1"},
+						},
+					},
+					VersionedResources: map[string][]metav1.APIResource{
+						"v1": {
+							{Name: "pods", Namespaced: true, Kind: "Pod"},
+						},
+					},
+				},
+				{
+					Group: metav1.APIGroup{
+						Versions: []metav1.GroupVersionForDiscovery{
+							{Version: "v1"},
+						},
+					},
+					VersionedResources: map[string][]metav1.APIResource{
+						"v1": {
+							{Name: "nodes", Namespaced: true, Kind: "Node"},
+						},
+					},
+				},
+			}
+			mapper := restmapper.NewDiscoveryRESTMapper(resources)
+			service := New(client, mapper, Options{})
+
+			p, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tt.podToApply)
+			if err != nil {
+				t.Fatalf("failed to convert pod to unstructured: %v", err)
+			}
+			unstructedPod := &unstructured.Unstructured{Object: p}
+			err = service.Create(context.Background(), unstructedPod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createPods() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			got, err := client.Resource(corev1.Resource("pods").WithVersion("v1")).Namespace("default").Get(context.Background(), tt.podToApply.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get pod when comparing: %v", err)
+			}
+			var gotPod corev1.Pod
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(got.UnstructuredContent(), &gotPod)
+			if err != nil {
+				t.Fatalf("failed to convert got unstructured to pod: %v", err)
+			}
+
+			if diff := cmp.Diff(*tt.podAfterApply, gotPod); diff != "" {
+				t.Errorf("createPods() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestResourceApplier_createPodsWithFilter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		podToCreate *corev1.Pod
+		filter      FilteringFunction
+		filtered    bool
+		wantErr     bool
+	}{
+		{
+			name: "create a Pod but it should not be created because of the filter",
+			podToCreate: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+					Labels: map[string]string{
+						"ignore": "true",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-1",
+						},
+					},
+				},
+			},
+			filter: func(ctx context.Context, resource *unstructured.Unstructured, clients *Clients) (bool, error) {
+				if resource.GetLabels()["ignore"] == "true" {
+					return false, nil
+				}
+				return true, nil
+			},
+			filtered: true,
+			wantErr:  false,
+		},
+		{
+			name: "create a Pod and it should be pass the filter",
+			podToCreate: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-1",
+						},
+					},
+				},
+			},
+			filter: func(ctx context.Context, resource *unstructured.Unstructured, clients *Clients) (bool, error) {
+				if resource.GetLabels()["ignore"] == "true" {
+					return false, nil
+				}
+				return true, nil
+			},
+			filtered: false,
+			wantErr:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := runtime.NewScheme()
+			v1.AddToScheme(s)
+			scheduling.AddToScheme(s)
+			storage.AddToScheme(s)
+			client := dynamicFake.NewSimpleDynamicClient(s)
+			resources := []*restmapper.APIGroupResources{
+				{
+					Group: metav1.APIGroup{
+						Versions: []metav1.GroupVersionForDiscovery{
+							{Version: "v1"},
+						},
+					},
+					VersionedResources: map[string][]metav1.APIResource{
+						"v1": {
+							{Name: "pods", Namespaced: true, Kind: "Pod"},
+						},
+					},
+				},
+				{
+					Group: metav1.APIGroup{
+						Versions: []metav1.GroupVersionForDiscovery{
+							{Version: "v1"},
+						},
+					},
+					VersionedResources: map[string][]metav1.APIResource{
+						"v1": {
+							{Name: "nodes", Namespaced: true, Kind: "Node"},
+						},
+					},
+				},
+			}
+			mapper := restmapper.NewDiscoveryRESTMapper(resources)
+			options := Options{
+				FilterBeforeCreating: map[schema.GroupVersionResource][]FilteringFunction{
+					{Group: "", Version: "v1", Resource: "pods"}: {tt.filter},
+				},
+			}
+			service := New(client, mapper, options)
+
+			p, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tt.podToCreate)
+			if err != nil {
+				t.Fatalf("failed to convert pod to unstructured: %v", err)
+			}
+			unstructedPod := &unstructured.Unstructured{Object: p}
+			err = service.Create(context.Background(), unstructedPod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createPods() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			got, err := client.Resource(corev1.Resource("pods").WithVersion("v1")).Namespace("default").Get(context.Background(), tt.podToCreate.Name, metav1.GetOptions{})
+
+			if tt.filtered {
+				if !errors.IsNotFound(err) {
+					t.Fatalf("pod should not be created but it exists: %v", err)
+				}
+				return
+			}
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("error = %v, wantErr %v", err, tt.wantErr)
+				}
+				return
+			}
+
+			var gotPod corev1.Pod
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(got.UnstructuredContent(), &gotPod)
+			if err != nil {
+				t.Fatalf("failed to convert got unstructured to pod: %v", err)
+			}
+
+			if diff := cmp.Diff(*tt.podToCreate, gotPod); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestResourceApplier_updatePods(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		originalPod    *corev1.Pod
+		updatePod      func(pod *corev1.Pod)
+		podAfterUpdate *corev1.Pod
+		wantErr        bool
+	}{
+		{
+			name: "update an unscheduled Pod",
+			originalPod: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-1",
+						},
+					},
+				},
+			},
+			updatePod: func(pod *corev1.Pod) {
+				pod.Spec.Containers[0].Image = "image-2"
+			},
+			podAfterUpdate: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-2",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "update an unscheduled Pod to be scheduled but it should not be updated",
+			originalPod: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-1",
+						},
+					},
+				},
+			},
+			updatePod: func(pod *corev1.Pod) {
+				pod.Spec.NodeName = "node-1"
+			},
+			podAfterUpdate: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-1",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "update a scheduled Pod but it should not be updated",
+			originalPod: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-1",
+						},
+					},
+				},
+			},
+			updatePod: func(pod *corev1.Pod) {
+				pod.Spec.Containers[0].Image = "image-2"
+			},
+			podAfterUpdate: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-1",
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-1",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := runtime.NewScheme()
+			v1.AddToScheme(s)
+			scheduling.AddToScheme(s)
+			storage.AddToScheme(s)
+			client := dynamicFake.NewSimpleDynamicClient(s)
+			resources := []*restmapper.APIGroupResources{
+				{
+					Group: metav1.APIGroup{
+						Versions: []metav1.GroupVersionForDiscovery{
+							{Version: "v1"},
+						},
+					},
+					VersionedResources: map[string][]metav1.APIResource{
+						"v1": {
+							{Name: "pods", Namespaced: true, Kind: "Pod"},
+						},
+					},
+				},
+				{
+					Group: metav1.APIGroup{
+						Versions: []metav1.GroupVersionForDiscovery{
+							{Version: "v1"},
+						},
+					},
+					VersionedResources: map[string][]metav1.APIResource{
+						"v1": {
+							{Name: "nodes", Namespaced: true, Kind: "Node"},
+						},
+					},
+				},
+			}
+			mapper := restmapper.NewDiscoveryRESTMapper(resources)
+			service := New(client, mapper, Options{})
+
+			p, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tt.originalPod)
+			if err != nil {
+				t.Fatalf("failed to convert pod to unstructured: %v", err)
+			}
+			unstructedPod := &unstructured.Unstructured{Object: p}
+			err = service.Create(context.Background(), unstructedPod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("updatePods() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			tt.updatePod(tt.originalPod)
+			p, err = runtime.DefaultUnstructuredConverter.ToUnstructured(tt.originalPod)
+			if err != nil {
+				t.Fatalf("failed to convert pod to unstructured: %v", err)
+			}
+			unstructedPod = &unstructured.Unstructured{Object: p}
+
+			err = service.Update(context.Background(), unstructedPod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("updatePods() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			got, err := client.Resource(corev1.Resource("pods").WithVersion("v1")).Namespace("default").Get(context.Background(), tt.originalPod.Name, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("failed to get pod when comparing: %v", err)
+			}
+			var gotPod corev1.Pod
+			err = runtime.DefaultUnstructuredConverter.FromUnstructured(got.UnstructuredContent(), &gotPod)
+			if err != nil {
+				t.Fatalf("failed to convert got unstructured to pod: %v", err)
+			}
+
+			if diff := cmp.Diff(*tt.podAfterUpdate, gotPod); diff != "" {
+				t.Errorf("updatePods() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestResourceApplier_deletePods(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		pod     *corev1.Pod
+		wantErr bool
+	}{
+		{
+			name: "delete a Pod",
+			pod: &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Pod",
+					APIVersion: "v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pod-1",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "container-1",
+							Image: "image-1",
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := runtime.NewScheme()
+			v1.AddToScheme(s)
+			scheduling.AddToScheme(s)
+			storage.AddToScheme(s)
+			client := dynamicFake.NewSimpleDynamicClient(s)
+			resources := []*restmapper.APIGroupResources{
+				{
+					Group: metav1.APIGroup{
+						Versions: []metav1.GroupVersionForDiscovery{
+							{Version: "v1"},
+						},
+					},
+					VersionedResources: map[string][]metav1.APIResource{
+						"v1": {
+							{Name: "pods", Namespaced: true, Kind: "Pod"},
+						},
+					},
+				},
+				{
+					Group: metav1.APIGroup{
+						Versions: []metav1.GroupVersionForDiscovery{
+							{Version: "v1"},
+						},
+					},
+					VersionedResources: map[string][]metav1.APIResource{
+						"v1": {
+							{Name: "nodes", Namespaced: true, Kind: "Node"},
+						},
+					},
+				},
+			}
+			mapper := restmapper.NewDiscoveryRESTMapper(resources)
+			service := New(client, mapper, Options{})
+
+			p, err := runtime.DefaultUnstructuredConverter.ToUnstructured(tt.pod)
+			if err != nil {
+				t.Fatalf("failed to convert pod to unstructured: %v", err)
+			}
+			unstructedPod := &unstructured.Unstructured{Object: p}
+			err = service.Create(context.Background(), unstructedPod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("deletePods() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			err = service.Delete(context.Background(), unstructedPod)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("deletePods() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			_, err = client.Resource(corev1.Resource("pods").WithVersion("v1")).Namespace("default").Get(context.Background(), tt.pod.Name, metav1.GetOptions{})
+			if err == nil {
+				t.Fatalf("pod should be deleted but it still exists")
+			}
+
+			if !errors.IsNotFound(err) && !tt.wantErr {
+				t.Fatalf("failed to check if pod is deleted: %v", err)
+			}
+		})
+	}
+}

--- a/simulator/server/di/di.go
+++ b/simulator/server/di/di.go
@@ -46,7 +46,6 @@ func NewDIContainer(
 	externalClient clientset.Interface,
 	externalDynamicClient dynamic.Interface,
 	simulatorPort int,
-	syncerOptions syncer.Options,
 	resourceapplierOptions resourceapplier.Options,
 ) (*Container, error) {
 	c := &Container{}
@@ -66,7 +65,7 @@ func NewDIContainer(
 	}
 	resourceApplierService := resourceapplier.New(dynamicClient, restMapper, resourceapplierOptions)
 	if resourceSyncEnabled {
-		c.resourceSyncer = syncer.New(externalDynamicClient, resourceApplierService, syncerOptions)
+		c.resourceSyncer = syncer.New(externalDynamicClient, resourceApplierService)
 	}
 	c.resourceWatcherService = resourcewatcher.NewService(client)
 

--- a/simulator/server/di/di.go
+++ b/simulator/server/di/di.go
@@ -14,6 +14,7 @@ import (
 
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/oneshotimporter"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/reset"
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/resourceapplier"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/resourcewatcher"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/scheduler"
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/snapshot"
@@ -62,8 +63,9 @@ func NewDIContainer(
 		extSnapshotSvc := snapshot.NewService(externalClient, c.schedulerService)
 		c.oneshotClusterResourceImporter = oneshotimporter.NewService(snapshotSvc, extSnapshotSvc)
 	}
+	resourceApplierService := resourceapplier.New(dynamicClient, restMapper, resourceapplier.Options{}) // TODO: make options configurable
 	if resourceSyncEnabled {
-		c.resourceSyncer = syncer.New(externalDynamicClient, dynamicClient, restMapper, syncerOptions)
+		c.resourceSyncer = syncer.New(externalDynamicClient, resourceApplierService, syncerOptions)
 	}
 	c.resourceWatcherService = resourcewatcher.NewService(client)
 

--- a/simulator/server/di/di.go
+++ b/simulator/server/di/di.go
@@ -47,6 +47,7 @@ func NewDIContainer(
 	externalDynamicClient dynamic.Interface,
 	simulatorPort int,
 	syncerOptions syncer.Options,
+	resourceapplierOptions resourceapplier.Options,
 ) (*Container, error) {
 	c := &Container{}
 
@@ -63,7 +64,7 @@ func NewDIContainer(
 		extSnapshotSvc := snapshot.NewService(externalClient, c.schedulerService)
 		c.oneshotClusterResourceImporter = oneshotimporter.NewService(snapshotSvc, extSnapshotSvc)
 	}
-	resourceApplierService := resourceapplier.New(dynamicClient, restMapper, resourceapplier.Options{}) // TODO: make options configurable
+	resourceApplierService := resourceapplier.New(dynamicClient, restMapper, resourceapplierOptions)
 	if resourceSyncEnabled {
 		c.resourceSyncer = syncer.New(externalDynamicClient, resourceApplierService, syncerOptions)
 	}

--- a/simulator/syncer/syncer.go
+++ b/simulator/syncer/syncer.go
@@ -5,7 +5,6 @@ import (
 
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -13,56 +12,45 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/resourceapplier"
 )
 
-type Service struct {
-	clients *Clients
-
-	gvrs               []schema.GroupVersionResource
-	mutatingFunctions  map[schema.GroupVersionResource][]MutatingFunction
-	filteringFunctions map[schema.GroupVersionResource][]FilteringFunction
+// DefaultGVRs is a list of GroupVersionResource that we sync by default (configurable with Options),
+// which is a suitable resource set for the vanilla scheduler.
+//
+// Note that this order matters - When first importing resources, we want to sync namespaces first, then priorityclasses, storageclasses...
+var DefaultGVRs = []schema.GroupVersionResource{
+	{Group: "", Version: "v1", Resource: "namespaces"},
+	{Group: "scheduling.k8s.io", Version: "v1", Resource: "priorityclasses"},
+	{Group: "storage.k8s.io", Version: "v1", Resource: "storageclasses"},
+	{Group: "", Version: "v1", Resource: "persistentvolumeclaims"},
+	{Group: "", Version: "v1", Resource: "nodes"},
+	{Group: "", Version: "v1", Resource: "persistentvolumes"},
+	{Group: "", Version: "v1", Resource: "pods"},
 }
 
-// Note: Clients and its fields are exposed intentionally so that users can use it in MutatingFunction and FilteringFunction.
-type Clients struct {
-	// SrcDynamicClient is the dynamic client for the source cluster, which the resource is supposed to be copied from.
-	SrcDynamicClient dynamic.Interface
-	// DestDynamicClient is the dynamic client for the destination cluster, which the resource is supposed to be copied to.
-	DestDynamicClient dynamic.Interface
-	RestMapper        meta.RESTMapper
+type Service struct {
+	gvrs                   []schema.GroupVersionResource
+	srcDynamicClient       dynamic.Interface
+	resourceApplierService *resourceapplier.Service
 }
 
 type Options struct {
 	// GVRsToSync is a list of GroupVersionResource that will be synced.
 	// If GVRsToSync is nil, defaultGVRs are used.
 	GVRsToSync []schema.GroupVersionResource
-	// AdditionalMutatingFunctions is a list of mutating functions that users add.
-	AdditionalMutatingFunctions map[schema.GroupVersionResource]MutatingFunction
-	// AdditionalFilteringFunctions is a list of filtering functions that users add.
-	AdditionalFilteringFunctions map[schema.GroupVersionResource]FilteringFunction
 }
 
-func New(srcDynamicClient, destDynamicClient dynamic.Interface, restMapper meta.RESTMapper, options Options) *Service {
+func New(srcDynamicClient dynamic.Interface, resourceApplierService *resourceapplier.Service, options Options) *Service {
 	s := &Service{
-		clients: &Clients{
-			SrcDynamicClient:  srcDynamicClient,
-			DestDynamicClient: destDynamicClient,
-			RestMapper:        restMapper,
-		},
-		gvrs:               DefaultGVRs,
-		mutatingFunctions:  map[schema.GroupVersionResource][]MutatingFunction{},
-		filteringFunctions: map[schema.GroupVersionResource][]FilteringFunction{},
+		gvrs:                   DefaultGVRs,
+		srcDynamicClient:       srcDynamicClient,
+		resourceApplierService: resourceApplierService,
 	}
 
 	if options.GVRsToSync != nil {
 		s.gvrs = options.GVRsToSync
 	}
-
-	s.addMutatingFunctoins(mandatoryMutatingFunctions)
-	s.addMutatingFunctoins(options.AdditionalMutatingFunctions)
-
-	s.addFilteringFunctoins(mandatoryFilteringFunctions)
-	s.addFilteringFunctoins(options.AdditionalFilteringFunctions)
 
 	return s
 }
@@ -70,7 +58,7 @@ func New(srcDynamicClient, destDynamicClient dynamic.Interface, restMapper meta.
 func (s *Service) Run(ctx context.Context) error {
 	klog.Info("Starting the cluster resource importer")
 
-	infFact := dynamicinformer.NewFilteredDynamicSharedInformerFactory(s.clients.SrcDynamicClient, 0, metav1.NamespaceAll, nil)
+	infFact := dynamicinformer.NewFilteredDynamicSharedInformerFactory(s.srcDynamicClient, 0, metav1.NamespaceAll, nil)
 	for _, gvr := range s.gvrs {
 		inf := infFact.ForResource(gvr).Informer()
 		_, err := inf.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -90,133 +78,6 @@ func (s *Service) Run(ctx context.Context) error {
 	return nil
 }
 
-// createResourceOnDestinationCluster creates the resource on the destination cluster.
-func (s *Service) createResourceOnDestinationCluster(
-	ctx context.Context,
-	resource *unstructured.Unstructured,
-) error {
-	// Extract the GroupVersionResource from the Unstructured object
-	gvk := resource.GroupVersionKind()
-	gvr, err := s.findGVRForGVK(gvk)
-	if err != nil {
-		return err
-	}
-
-	// Namespaces resources should be created within the namespace defined in the Unstructured object
-	namespace := resource.GetNamespace()
-
-	// Run the filtering function for the resource.
-	if ok, err := s.filterResource(ctx, gvr, resource, Add); !ok || err != nil {
-		return err
-	}
-
-	// When creating a resource on the destination cluster, we must remove the metadata such as UID and Generation.
-	// It's done for all resources.
-	resource = removeUnnecessaryMetadata(resource)
-
-	// Run the mutating function for the resource.
-	resource, err = s.mutateResource(ctx, gvr, resource, Add)
-	if err != nil {
-		return xerrors.Errorf("failed to mutate resource: %w", err)
-	}
-
-	// Create the resource on the destination cluster using the dynamic client
-	_, err = s.clients.DestDynamicClient.Resource(gvr).Namespace(namespace).Create(
-		ctx,
-		resource,
-		metav1.CreateOptions{},
-	)
-	if err != nil {
-		return xerrors.Errorf("failed to create resource: %w", err)
-	}
-
-	return nil
-}
-
-func (s *Service) updateResourceOnDestinationCluster(
-	ctx context.Context,
-	resource *unstructured.Unstructured,
-) error {
-	// Extract the GroupVersionResource from the Unstructured object.
-	gvk := resource.GroupVersionKind()
-	gvr, err := s.findGVRForGVK(gvk)
-	if err != nil {
-		return err
-	}
-
-	// Namespaces resources should be created within the namespace defined in the Unstructured object.
-	namespace := resource.GetNamespace()
-
-	// Run the filtering function for the resource.
-	if ok, err := s.filterResource(ctx, gvr, resource, Update); !ok || err != nil {
-		return err
-	}
-
-	// Run the mutating function for the resource.
-	resource, err = s.mutateResource(ctx, gvr, resource, Update)
-	if err != nil {
-		return xerrors.Errorf("failed to mutate resource: %w", err)
-	}
-
-	// Create the resource on the destination cluster using the dynamic client
-	_, err = s.clients.DestDynamicClient.Resource(gvr).Namespace(namespace).Update(
-		ctx,
-		resource,
-		metav1.UpdateOptions{},
-	)
-	if err != nil {
-		return xerrors.Errorf("failed to create resource: %w", err)
-	}
-
-	return nil
-}
-
-// removeUnnecessaryMetadata removes the metadata from the resource.
-func removeUnnecessaryMetadata(resource *unstructured.Unstructured) *unstructured.Unstructured {
-	resource.SetUID("")
-	resource.SetGeneration(0)
-	resource.SetResourceVersion("")
-
-	return resource
-}
-
-func (s *Service) deleteResourceOnDestinationCluster(
-	ctx context.Context,
-	resource *unstructured.Unstructured,
-) error {
-	// Extract the GroupVersionResource from the Unstructured object
-	gvk := resource.GroupVersionKind()
-	gvr, err := s.findGVRForGVK(gvk)
-	if err != nil {
-		return err
-	}
-
-	// Namespaces resources should be created within the namespace defined in the Unstructured object
-	namespace := resource.GetNamespace()
-
-	// Create the resource on the destination cluster using the dynamic client
-	err = s.clients.DestDynamicClient.Resource(gvr).Namespace(namespace).Delete(
-		ctx,
-		resource.GetName(),
-		metav1.DeleteOptions{},
-	)
-	if err != nil {
-		return xerrors.Errorf("failed to delete resource: %w", err)
-	}
-
-	return nil
-}
-
-// findGVRForGVK uses the discovery client to get the GroupVersionResource for a given GroupVersionKind.
-func (s *Service) findGVRForGVK(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
-	m, err := s.clients.RestMapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-	if err != nil {
-		return schema.GroupVersionResource{}, err
-	}
-
-	return m.Resource, nil
-}
-
 func (s *Service) addFunc(obj interface{}) {
 	ctx := context.Background()
 	unstructObj, ok := obj.(*unstructured.Unstructured)
@@ -225,7 +86,7 @@ func (s *Service) addFunc(obj interface{}) {
 		return
 	}
 
-	err := s.createResourceOnDestinationCluster(ctx, unstructObj)
+	err := s.resourceApplierService.Create(ctx, unstructObj)
 	if err != nil {
 		klog.ErrorS(err, "Failed to create resource on destination cluster")
 	}
@@ -239,7 +100,7 @@ func (s *Service) updateFunc(_, newObj interface{}) {
 		return
 	}
 
-	err := s.updateResourceOnDestinationCluster(ctx, unstructObj)
+	err := s.resourceApplierService.Update(ctx, unstructObj)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// We just ignore the not found error because the scheduler may preempt the Pods, or users may remove the resources for debugging.
@@ -258,7 +119,7 @@ func (s *Service) deleteFunc(obj interface{}) {
 		return
 	}
 
-	err := s.deleteResourceOnDestinationCluster(ctx, unstructObj)
+	err := s.resourceApplierService.Delete(ctx, unstructObj)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// We just ignore the not found error because the scheduler may preempt the Pods, or users may remove the resources for debugging.
@@ -267,60 +128,4 @@ func (s *Service) deleteFunc(obj interface{}) {
 			klog.ErrorS(err, "Failed to delete resource on destination cluster")
 		}
 	}
-}
-
-func (s *Service) addMutatingFunctoins(m map[schema.GroupVersionResource]MutatingFunction) {
-	for k, v := range m {
-		if s.mutatingFunctions[k] == nil {
-			s.mutatingFunctions[k] = []MutatingFunction{v}
-		} else {
-			s.mutatingFunctions[k] = append(s.mutatingFunctions[k], v)
-		}
-	}
-}
-
-func (s *Service) addFilteringFunctoins(m map[schema.GroupVersionResource]FilteringFunction) {
-	for k, v := range m {
-		if s.filteringFunctions[k] == nil {
-			s.filteringFunctions[k] = []FilteringFunction{v}
-		} else {
-			s.filteringFunctions[k] = append(s.filteringFunctions[k], v)
-		}
-	}
-}
-
-func (s *Service) mutateResource(ctx context.Context, gvr schema.GroupVersionResource, resource *unstructured.Unstructured, event Event) (*unstructured.Unstructured, error) {
-	mutatingFns, ok := s.mutatingFunctions[gvr]
-	if !ok {
-		return resource, nil
-	}
-
-	for _, mutatingFn := range mutatingFns {
-		var err error
-		resource, err = mutatingFn(ctx, resource, s.clients, event)
-		if err != nil {
-			return resource, err
-		}
-	}
-
-	return resource, nil
-}
-
-func (s *Service) filterResource(ctx context.Context, gvr schema.GroupVersionResource, resource *unstructured.Unstructured, event Event) (bool, error) {
-	filteringFns, ok := s.filteringFunctions[gvr]
-	if !ok {
-		return true, nil
-	}
-
-	for _, filteringFn := range filteringFns {
-		ok, err := filteringFn(ctx, resource, s.clients, event)
-		if err != nil {
-			return false, err
-		}
-		if !ok {
-			return false, nil
-		}
-	}
-
-	return true, nil
 }

--- a/simulator/syncer/syncer.go
+++ b/simulator/syncer/syncer.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/dynamic/dynamicinformer"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
+
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/resourceapplier"
 )
 

--- a/simulator/syncer/syncer.go
+++ b/simulator/syncer/syncer.go
@@ -36,21 +36,15 @@ type Service struct {
 	resourceApplierService *resourceapplier.Service
 }
 
-type Options struct {
-	// GVRsToSync is a list of GroupVersionResource that will be synced.
-	// If GVRsToSync is nil, defaultGVRs are used.
-	GVRsToSync []schema.GroupVersionResource
-}
-
-func New(srcDynamicClient dynamic.Interface, resourceApplierService *resourceapplier.Service, options Options) *Service {
+func New(srcDynamicClient dynamic.Interface, resourceApplierService *resourceapplier.Service) *Service {
 	s := &Service{
 		gvrs:                   DefaultGVRs,
 		srcDynamicClient:       srcDynamicClient,
 		resourceApplierService: resourceApplierService,
 	}
 
-	if options.GVRsToSync != nil {
-		s.gvrs = options.GVRsToSync
+	if resourceApplierService.GVRsToSync != nil {
+		s.gvrs = resourceApplierService.GVRsToSync
 	}
 
 	return s

--- a/simulator/syncer/syncer_test.go
+++ b/simulator/syncer/syncer_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	scheduling "k8s.io/kubernetes/pkg/apis/scheduling/v1"
 	storage "k8s.io/kubernetes/pkg/apis/storage/v1"
+	"sigs.k8s.io/kube-scheduler-simulator/simulator/resourceapplier"
 )
 
 //nolint:gocognit // it is because of huge test cases.
@@ -389,7 +390,8 @@ func TestSyncerWithPod(t *testing.T) {
 				},
 			}
 			mapper := restmapper.NewDiscoveryRESTMapper(resources)
-			service := New(src, dest, mapper, Options{})
+			resourceApplier := resourceapplier.New(dest, mapper, resourceapplier.Options{})
+			service := New(src, resourceApplier, Options{})
 
 			ctx, cancel := context.WithCancel(context.Background())
 

--- a/simulator/syncer/syncer_test.go
+++ b/simulator/syncer/syncer_test.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	scheduling "k8s.io/kubernetes/pkg/apis/scheduling/v1"
 	storage "k8s.io/kubernetes/pkg/apis/storage/v1"
+
 	"sigs.k8s.io/kube-scheduler-simulator/simulator/resourceapplier"
 )
 

--- a/simulator/syncer/syncer_test.go
+++ b/simulator/syncer/syncer_test.go
@@ -392,7 +392,7 @@ func TestSyncerWithPod(t *testing.T) {
 			}
 			mapper := restmapper.NewDiscoveryRESTMapper(resources)
 			resourceApplier := resourceapplier.New(dest, mapper, resourceapplier.Options{})
-			service := New(src, resourceApplier, Options{})
+			service := New(src, resourceApplier)
 
 			ctx, cancel := context.WithCancel(context.Background())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide/first-contribution.md#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/sig-testing/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add related area tag(s):
/area web
/area simulator
/area scenario

Add one of the following kinds:
/kind bug

/kind documentation
/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/area simulator
/kind cleanup

#### What this PR does / why we need it:

`syncer` and `oneshotimporter` have their own logic of applying resources. They can be generalized and the replaying feature (#395) can use it.

This PR separates that of `syncer` and makes it a module `resourceapplier`.

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Part of #395 

#### Special notes for your reviewer:

I'll create another PR to refactor `oneshotimporter` to use `resourceapplier`.

/label tide/merge-method-squash
