### PR TITLE
Fix issue #420: Add troubleshooting section for client rate limiter errors in import-cluster-resources

### DIFF
--- a/simulator/docs/import-cluster-resources.md
+++ b/simulator/docs/import-cluster-resources.md
@@ -90,3 +90,16 @@ resourceApplierOptions := resourceapplier.Options{
 
 > [!NOTE]
 > Right now, one-shot import cannot change which resources to import.
+
+## Troubleshooting
+
+### Client Rate Limiter Errors
+
+When importing resources from large clusters, you might encounter "context deadline" or client rate limiter errors. This typically happens when the default QPS (Queries Per Second) and Burst settings are too low to handle the volume of API requests needed for resource synchronization.
+
+**Solution**: The simulator automatically sets higher QPS and Burst limits for external cluster connections to prevent these errors:
+
+- QPS: 400 (instead of the default 5)
+- Burst: 1200 (instead of the default 10)
+
+These values are automatically applied in the code when creating the external cluster client configuration, so no manual kubeconfig modification is required. The simulator handles large cluster imports efficiently without additional user configuration.


### PR DESCRIPTION
#### What type of PR is this?
/area simulator
/kind documentation

#### What this PR does / why we need it:

This PR adds a troubleshooting section to the `import-cluster-resources.md` documentation to address client rate limiter errors that users encounter when importing resources from large clusters.

**Changes made:**
- Added a new "Troubleshooting" section with subsection "Client Rate Limiter Errors"
- Explained the root cause: default QPS (5) and Burst (10) settings are too low for large cluster imports
- Documented the automatic solution: simulator sets QPS to 400 and Burst to 1200 in code
- Clarified that no manual kubeconfig modification is required

This improvement helps users understand why they might see "context deadline" errors and reassures them that the simulator handles this automatically.

#### Which issue(s) this PR fixes:
Fixes #420

#### Special notes for your reviewer:

This is a documentation-only change that improves user experience by providing clear guidance on a common issue. The technical solution (automatic QPS/Burst configuration) is already implemented in the code, this PR just documents it for users.

/label tide/merge-method-squash